### PR TITLE
Update include list when exporting shipments

### DIFF
--- a/apps/exports/src/data/relationships.ts
+++ b/apps/exports/src/data/relationships.ts
@@ -28,7 +28,14 @@ export const exportRelationships: Record<ResourceWithRelationship, string[]> = {
   ],
   payment_methods: ['order'],
   prices: ['sku', 'price_tiers'],
-  shipments: ['order', 'shipping_category', 'shipping_method', 'tags'],
+  shipments: [
+    'order',
+    'shipping_category',
+    'shipping_method',
+    'origin_address',
+    'shipping_address',
+    'parcels'
+  ],
   shipping_categories: ['skus'],
   shipping_methods: ['shipments'],
   skus: [


### PR DESCRIPTION
Closes https://github.com/commercelayer/issues-app/issues/135

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I have updated the list of available include when exporting shipments.
Since now API allows also to include `origin_address`, `shipping_address` and `parcels`.

<img width="697" alt="image" src="https://github.com/user-attachments/assets/b21048fc-ab32-4455-a208-a552971f513e">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
