### PR TITLE
Shipments: update app-elements to show `parcel.attachments`

### DIFF
--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.0.8",
-    "@commercelayer/sdk": "6.9.1",
+    "@commercelayer/app-elements": "^2.2.5",
+    "@commercelayer/sdk": "6.10.0",
     "@hookform/resolvers": "^3.6.0",
     "lodash": "^4.17.21",
     "query-string": "^9.0.0",

--- a/apps/shipments/src/hooks/useShipmentDetails.tsx
+++ b/apps/shipments/src/hooks/useShipmentDetails.tsx
@@ -17,6 +17,7 @@ export const shipmentIncludeAttribute = [
   'parcels',
   'parcels.package',
   'parcels.parcel_line_items',
+  'parcels.attachments',
 
   'carrier_accounts'
 ]

--- a/apps/shipments/src/main.tsx
+++ b/apps/shipments/src/main.tsx
@@ -25,7 +25,6 @@ const Main: React.FC<ClAppProps> = (props) => (
           kind='shipments'
           appSlug='shipments'
           devMode={isDev}
-          reauthenticateOnInvalidAuth={!isDev && props?.onInvalidAuth == null}
           loadingElement={<div />}
           {...props}
         >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,11 +698,11 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.0.8
-        version: 2.1.1(@commercelayer/sdk@6.9.1)(query-string@9.0.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.52.1(react@18.3.1))(react@18.3.1)(wouter@3.3.1(react@18.3.1))
+        specifier: ^2.2.5
+        version: 2.2.5(@commercelayer/sdk@6.10.0)(query-string@9.0.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.52.1(react@18.3.1))(react@18.3.1)(wouter@3.3.1(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.9.1
-        version: 6.9.1
+        specifier: 6.10.0
+        version: 6.10.0
       '@hookform/resolvers':
         specifier: ^3.6.0
         version: 3.9.0(react-hook-form@7.52.1(react@18.3.1))
@@ -1191,19 +1191,19 @@ importers:
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@5.3.4(@types/node@20.14.11)(terser@5.31.3))
+        version: 4.3.1(vite@5.3.4(@types/node@22.1.0)(terser@5.31.3))
       rollup-plugin-external-globals:
         specifier: ^0.11.0
         version: 0.11.0(rollup@4.18.1)
       vite:
         specifier: ^5.3.4
-        version: 5.3.4(@types/node@20.14.11)(terser@5.31.3)
+        version: 5.3.4(@types/node@22.1.0)(terser@5.31.3)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.11)(terser@5.31.3))
+        version: 4.3.2(typescript@5.5.4)(vite@5.3.4(@types/node@22.1.0)(terser@5.31.3))
       vitest:
         specifier: ^2.0.4
-        version: 2.0.4(@types/node@20.14.11)(jsdom@24.1.1)(terser@5.31.3)
+        version: 2.0.4(@types/node@22.1.0)(jsdom@24.1.1)(terser@5.31.3)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -6318,7 +6318,7 @@ snapshots:
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
-      type-fest: 4.24.0
+      type-fest: 4.22.1
       wouter: 3.3.1(react@18.3.1)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -6374,7 +6374,7 @@ snapshots:
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
-      type-fest: 4.24.0
+      type-fest: 4.22.1
       wouter: 3.3.1(react@18.3.1)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -6402,7 +6402,7 @@ snapshots:
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
-      type-fest: 4.24.0
+      type-fest: 4.22.1
       wouter: 3.3.1(react@18.3.1)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -6430,7 +6430,7 @@ snapshots:
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
-      type-fest: 4.24.0
+      type-fest: 4.22.1
       wouter: 3.3.1(react@18.3.1)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -6486,7 +6486,7 @@ snapshots:
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
-      type-fest: 4.24.0
+      type-fest: 4.22.1
       wouter: 3.3.1(react@18.3.1)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -6495,6 +6495,34 @@ snapshots:
   '@commercelayer/app-elements@2.2.0(@commercelayer/sdk@6.11.0)(query-string@9.0.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.52.1(react@18.3.1))(react@18.3.1)(wouter@3.3.1(react@18.3.1))':
     dependencies:
       '@commercelayer/sdk': 6.11.0
+      '@types/lodash': 4.17.7
+      '@types/react': 18.3.3
+      '@types/react-datepicker': 6.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react-dom': 18.3.0
+      classnames: 2.5.1
+      jwt-decode: 4.0.0
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      query-string: 9.0.0
+      react: 18.3.1
+      react-currency-input-field: 3.8.0(react@18.3.1)
+      react-datepicker: 7.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-gtm-module: 2.0.11
+      react-hook-form: 7.52.1(react@18.3.1)
+      react-select: 5.8.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr: 2.2.5(react@18.3.1)
+      ts-invariant: 0.10.3
+      type-fest: 4.23.0
+      wouter: 3.3.1(react@18.3.1)
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@commercelayer/app-elements@2.2.5(@commercelayer/sdk@6.10.0)(query-string@9.0.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.52.1(react@18.3.1))(react@18.3.1)(wouter@3.3.1(react@18.3.1))':
+    dependencies:
+      '@commercelayer/sdk': 6.10.0
       '@types/lodash': 4.17.7
       '@types/react': 18.3.3
       '@types/react-datepicker': 6.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6542,7 +6570,7 @@ snapshots:
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
-      type-fest: 4.24.0
+      type-fest: 4.23.0
       wouter: 3.3.1(react@18.3.1)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -7865,6 +7893,17 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
       vite: 5.3.4(@types/node@20.14.9)(terser@5.31.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.3.1(vite@5.3.4(@types/node@22.1.0)(terser@5.31.3))':
+    dependencies:
+      '@babel/core': 7.24.9
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.9)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.9)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.3.4(@types/node@22.1.0)(terser@5.31.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -11771,6 +11810,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.0.4(@types/node@22.1.0)(terser@5.31.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.5
+      pathe: 1.1.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.0(@types/node@22.1.0)(terser@5.31.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.0.5(@types/node@22.1.0)(terser@5.31.3):
     dependencies:
       cac: 6.7.14
@@ -11855,13 +11912,13 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.5.4)(vite@5.3.4(@types/node@20.14.11)(terser@5.31.3)):
+  vite-tsconfig-paths@4.3.2(typescript@5.5.4)(vite@5.3.4(@types/node@22.1.0)(terser@5.31.3)):
     dependencies:
       debug: 4.3.5
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.5.4)
     optionalDependencies:
-      vite: 5.3.4(@types/node@20.14.11)(terser@5.31.3)
+      vite: 5.3.4(@types/node@22.1.0)(terser@5.31.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11945,6 +12002,16 @@ snapshots:
       rollup: 4.18.1
     optionalDependencies:
       '@types/node': 20.14.9
+      fsevents: 2.3.3
+      terser: 5.31.3
+
+  vite@5.3.4(@types/node@22.1.0)(terser@5.31.3):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.1
+    optionalDependencies:
+      '@types/node': 22.1.0
       fsevents: 2.3.3
       terser: 5.31.3
 
@@ -12047,7 +12114,7 @@ snapshots:
       strip-literal: 2.0.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.4.0(@types/node@20.12.11)(terser@5.31.3)
+      vite: 5.3.4(@types/node@20.12.11)(terser@5.31.3)
       vite-node: 1.6.0(@types/node@20.12.11)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12082,7 +12149,7 @@ snapshots:
       strip-literal: 2.0.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.4.0(@types/node@20.12.8)(terser@5.31.3)
+      vite: 5.3.4(@types/node@20.12.8)(terser@5.31.3)
       vite-node: 1.6.0(@types/node@20.12.8)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12117,7 +12184,7 @@ snapshots:
       strip-literal: 2.0.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.4.0(@types/node@20.14.11)(terser@5.31.3)
+      vite: 5.3.4(@types/node@20.14.11)(terser@5.31.3)
       vite-node: 1.6.0(@types/node@20.14.11)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12152,7 +12219,7 @@ snapshots:
       strip-literal: 2.0.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.4.0(@types/node@20.14.2)(terser@5.31.3)
+      vite: 5.3.4(@types/node@20.14.2)(terser@5.31.3)
       vite-node: 1.6.0(@types/node@20.14.2)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12187,7 +12254,7 @@ snapshots:
       strip-literal: 2.0.0
       tinybench: 2.8.0
       tinypool: 0.8.4
-      vite: 5.4.0(@types/node@20.14.7)(terser@5.31.3)
+      vite: 5.3.4(@types/node@20.14.7)(terser@5.31.3)
       vite-node: 1.6.0(@types/node@20.14.7)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12256,7 +12323,7 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@20.12.11)(terser@5.31.3)
+      vite: 5.3.4(@types/node@20.12.11)(terser@5.31.3)
       vite-node: 2.0.4(@types/node@20.12.11)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -12306,7 +12373,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.0.4(@types/node@20.14.11)(jsdom@24.1.1)(terser@5.31.3):
+  vitest@2.0.4(@types/node@22.1.0)(jsdom@24.1.1)(terser@5.31.3):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.4
@@ -12324,11 +12391,11 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@20.14.11)(terser@5.31.3)
-      vite-node: 2.0.4(@types/node@20.14.11)(terser@5.31.3)
+      vite: 5.3.4(@types/node@22.1.0)(terser@5.31.3)
+      vite-node: 2.0.4(@types/node@22.1.0)(terser@5.31.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.14.11
+      '@types/node': 22.1.0
       jsdom: 24.1.1
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## What I did

In app-shipments:
- updated app-elements
- add `parcels.attachments` as include when fetching shipment details

In this way, we show attachments URL in the parcel box


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
