### PR TITLE
Add bundle detail page to `bundles` app

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -15,7 +15,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.3.0",
+    "@commercelayer/app-elements": "2.3.3",
     "@commercelayer/sdk": "6.14.1",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",

--- a/apps/bundles/src/App.tsx
+++ b/apps/bundles/src/App.tsx
@@ -1,3 +1,4 @@
+import { BundleDetails } from '#pages/BundleDetails'
 import { BundlesList } from '#pages/BundlesList'
 import { ErrorNotFound } from '#pages/ErrorNotFound'
 import { Filters } from '#pages/Filters'
@@ -21,6 +22,9 @@ export const App: FC<AppProps> = ({ routerBase }) => {
         </Route>
         <Route path={appRoutes.filters.path}>
           <Filters />
+        </Route>
+        <Route path={appRoutes.details.path}>
+          <BundleDetails />
         </Route>
         <Route>
           <ErrorNotFound />

--- a/apps/bundles/src/components/BundleDescription.tsx
+++ b/apps/bundles/src/components/BundleDescription.tsx
@@ -1,0 +1,25 @@
+import { makeBundle } from '#mocks'
+import { Avatar, Spacer, Text } from '@commercelayer/app-elements'
+import type { Bundle } from '@commercelayer/sdk'
+import type { FC } from 'react'
+
+interface Props {
+  bundle: Bundle
+}
+
+export const BundleDescription: FC<Props> = ({ bundle = makeBundle() }) => {
+  return (
+    <div className='border-t border-b'>
+      <Spacer top='6' bottom='6'>
+        <div className='flex items-center gap-6'>
+          <Avatar
+            alt={bundle.name}
+            src={bundle.image_url as `https://${string}`}
+            size='large'
+          />
+          <Text variant='info'>{bundle.description}</Text>
+        </div>
+      </Spacer>
+    </div>
+  )
+}

--- a/apps/bundles/src/components/BundleInfo.tsx
+++ b/apps/bundles/src/components/BundleInfo.tsx
@@ -1,0 +1,57 @@
+import { makeBundle } from '#mocks'
+import {
+  formatDate,
+  ListDetailsItem,
+  Section,
+  Text,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import type { Bundle } from '@commercelayer/sdk'
+import type { FC } from 'react'
+
+interface Props {
+  bundle: Bundle
+}
+
+export const BundleInfo: FC<Props> = ({ bundle = makeBundle() }) => {
+  const { user } = useTokenProvider()
+
+  return (
+    <Section title='Info'>
+      {bundle.market != null && (
+        <ListDetailsItem label='Market' gutter='none'>
+          <Text tag='div'>{bundle.market?.name}</Text>
+        </ListDetailsItem>
+      )}
+      <ListDetailsItem label='Price' gutter='none'>
+        <Text tag='div'>{bundle.formatted_price_amount}</Text>
+      </ListDetailsItem>
+      {bundle.formatted_price_amount !== bundle.formatted_compare_at_amount &&
+        bundle.formatted_compare_at_amount != null && (
+          <ListDetailsItem label='Original price' gutter='none'>
+            <Text tag='div' variant='info'>
+              <s>{bundle.formatted_compare_at_amount}</s>
+            </Text>
+          </ListDetailsItem>
+        )}
+      <ListDetailsItem label='Created' gutter='none'>
+        <Text tag='div'>
+          {formatDate({
+            isoDate: bundle.created_at,
+            timezone: user?.timezone,
+            format: 'full'
+          })}
+        </Text>
+      </ListDetailsItem>
+      <ListDetailsItem label='Updated' gutter='none'>
+        <Text tag='div'>
+          {formatDate({
+            isoDate: bundle.updated_at,
+            timezone: user?.timezone,
+            format: 'full'
+          })}
+        </Text>
+      </ListDetailsItem>
+    </Section>
+  )
+}

--- a/apps/bundles/src/components/BundleSkuList.tsx
+++ b/apps/bundles/src/components/BundleSkuList.tsx
@@ -1,0 +1,34 @@
+import { useSkuListItems } from '#hooks/useSkuListItems'
+import { makeBundle } from '#mocks'
+import { Section, SkeletonTemplate } from '@commercelayer/app-elements'
+import type { Bundle } from '@commercelayer/sdk'
+import type { FC } from 'react'
+import { ListItemSkuListItem } from './ListItemSkuListItem'
+
+interface Props {
+  bundle: Bundle
+}
+
+export const BundleSkuList: FC<Props> = ({ bundle = makeBundle() }) => {
+  const skuListId = bundle.sku_list?.id
+
+  const { skuListItems, isLoadingItems } = useSkuListItems(skuListId ?? '')
+  let totalQuantity = 0
+  skuListItems?.forEach((item) => {
+    totalQuantity += item?.quantity ?? 0
+  })
+
+  const isLoading = isLoadingItems || skuListId == null || skuListItems == null
+
+  return (
+    <Section title={`${bundle.sku_list?.name} (${totalQuantity})`}>
+      <SkeletonTemplate isLoading={isLoading}>
+        {skuListItems != null
+          ? skuListItems.map((item) => (
+              <ListItemSkuListItem key={item.sku_code} resource={item} />
+            ))
+          : null}
+      </SkeletonTemplate>
+    </Section>
+  )
+}

--- a/apps/bundles/src/components/ListItemSkuListItem.tsx
+++ b/apps/bundles/src/components/ListItemSkuListItem.tsx
@@ -1,0 +1,29 @@
+import { makeSkuListItem } from '#mocks'
+import {
+  ResourceListItem,
+  withSkeletonTemplate
+} from '@commercelayer/app-elements'
+import type { SkuListItem } from '@commercelayer/sdk'
+
+interface Props {
+  resource?: SkuListItem
+  isLoading?: boolean
+  delayMs?: number
+}
+
+export const ListItemSkuListItem = withSkeletonTemplate<Props>(
+  ({
+    resource = makeSkuListItem(),
+    isLoading,
+    delayMs
+  }): JSX.Element | null => {
+    return (
+      <ResourceListItem
+        resource={resource}
+        isLoading={isLoading}
+        delayMs={delayMs}
+        showRightContent
+      />
+    )
+  }
+)

--- a/apps/bundles/src/data/routes.ts
+++ b/apps/bundles/src/data/routes.ts
@@ -9,5 +9,6 @@ export type AppRoute = keyof typeof appRoutes
 export const appRoutes = {
   home: createRoute('/'),
   list: createRoute('/list/'),
-  filters: createRoute('/filters/')
+  filters: createRoute('/filters/'),
+  details: createRoute('/list/:bundleId/')
 }

--- a/apps/bundles/src/hooks/useBundleDetails.tsx
+++ b/apps/bundles/src/hooks/useBundleDetails.tsx
@@ -1,0 +1,40 @@
+import { isMockedId, makeBundle } from '#mocks'
+import { useCoreApi } from '@commercelayer/app-elements'
+import type { Bundle } from '@commercelayer/sdk'
+import type { KeyedMutator } from 'swr'
+
+/**
+ * Retrieves a `Bundle` resource.
+ * @param id - The `id` of the wanted `Bundle` resource.
+ * @returns a resolved `Bundle`.
+ */
+
+export function useBundleDetails(id: Bundle['id']): {
+  bundle: Bundle
+  isLoading: boolean
+  error: any
+  mutateBundle: KeyedMutator<Bundle>
+} {
+  const {
+    data: bundle,
+    isLoading,
+    error,
+    mutate: mutateBundle
+  } = useCoreApi(
+    'bundles',
+    'retrieve',
+    isMockedId(id)
+      ? null
+      : [
+          id,
+          {
+            include: ['market', 'sku_list']
+          }
+        ],
+    {
+      fallbackData: makeBundle()
+    }
+  )
+
+  return { bundle, error, isLoading, mutateBundle }
+}

--- a/apps/bundles/src/hooks/useSkuListItems.tsx
+++ b/apps/bundles/src/hooks/useSkuListItems.tsx
@@ -1,0 +1,28 @@
+import { isMockedId } from '#mocks'
+import { useCoreApi } from '@commercelayer/app-elements'
+import type { SkuListItem } from '@commercelayer/sdk'
+
+export function useSkuListItems(id: string): {
+  skuListItems?: SkuListItem[]
+  isLoadingItems: boolean
+} {
+  const pauseRequest = isMockedId(id) || id === ''
+  const { data: skuListItems, isLoading: isLoadingItems } = useCoreApi(
+    'sku_lists',
+    'sku_list_items',
+    pauseRequest
+      ? null
+      : [
+          id,
+          {
+            include: ['sku'],
+            sort: {
+              position: 'asc'
+            },
+            pageSize: 25
+          }
+        ]
+  )
+
+  return { skuListItems, isLoadingItems }
+}

--- a/apps/bundles/src/mocks/index.ts
+++ b/apps/bundles/src/mocks/index.ts
@@ -1,6 +1,7 @@
 import type { Resource } from '@commercelayer/sdk'
 
 export * from './resources/bundles'
+export * from './resources/skuListItems'
 
 export const isMockedId = (id: string): boolean => {
   return id.startsWith('fake-')

--- a/apps/bundles/src/mocks/resources/skuListItems.ts
+++ b/apps/bundles/src/mocks/resources/skuListItems.ts
@@ -1,0 +1,8 @@
+import type { SkuListItem } from '@commercelayer/sdk'
+import { makeResource } from '../resource'
+
+export const makeSkuListItem = (): SkuListItem => {
+  return {
+    ...makeResource('sku_list_items')
+  }
+}

--- a/apps/bundles/src/pages/BundleDetails.tsx
+++ b/apps/bundles/src/pages/BundleDetails.tsx
@@ -1,0 +1,196 @@
+import {
+  Button,
+  EmptyState,
+  PageLayout,
+  ResourceMetadata,
+  ResourceTags,
+  SkeletonTemplate,
+  Spacer,
+  goBack,
+  useCoreSdkProvider,
+  useEditMetadataOverlay,
+  useOverlay,
+  useTokenProvider,
+  type PageHeadingProps
+} from '@commercelayer/app-elements'
+import { Link, useLocation, useRoute } from 'wouter'
+
+import { BundleDescription } from '#components/BundleDescription'
+import { BundleInfo } from '#components/BundleInfo'
+import { BundleSkuList } from '#components/BundleSkuList'
+import { appRoutes } from '#data/routes'
+import { useBundleDetails } from '#hooks/useBundleDetails'
+import { isMockedId } from '#mocks'
+import { useState, type FC } from 'react'
+
+export const BundleDetails: FC = () => {
+  const {
+    settings: { mode },
+    canUser
+  } = useTokenProvider()
+
+  const [, setLocation] = useLocation()
+  const [, params] = useRoute<{ bundleId: string }>(appRoutes.details.path)
+
+  const bundleId = params?.bundleId ?? ''
+  const goBackUrl = appRoutes.list.makePath({})
+
+  const { bundle, isLoading, error } = useBundleDetails(bundleId)
+
+  const { sdkClient } = useCoreSdkProvider()
+
+  const { Overlay: DeleteOverlay, open, close } = useOverlay()
+  const [isDeleteting, setIsDeleting] = useState(false)
+  const { Overlay: EditMetadataOverlay, show: showEditMetadataOverlay } =
+    useEditMetadataOverlay()
+
+  const pageTitle = bundle.name ?? 'Bundles'
+
+  const pageToolbar: PageHeadingProps['toolbar'] = {
+    buttons: [],
+    dropdownItems: []
+  }
+
+  if (canUser('update', 'bundles')) {
+    pageToolbar.dropdownItems?.push([
+      {
+        label: 'Set metadata',
+        onClick: () => {
+          showEditMetadataOverlay()
+        }
+      }
+    ])
+  }
+
+  if (canUser('destroy', 'bundles')) {
+    pageToolbar.dropdownItems?.push([
+      {
+        label: 'Delete',
+        onClick: () => {
+          open()
+        }
+      }
+    ])
+  }
+
+  return (
+    <PageLayout
+      mode={mode}
+      title={
+        <SkeletonTemplate isLoading={isLoading}>{pageTitle}</SkeletonTemplate>
+      }
+      description={
+        <SkeletonTemplate isLoading={isLoading}>{bundle.code}</SkeletonTemplate>
+      }
+      navigationButton={{
+        onClick: () => {
+          goBack({
+            setLocation,
+            defaultRelativePath: appRoutes.list.makePath({})
+          })
+        },
+        label: 'Bundles',
+        icon: 'arrowLeft'
+      }}
+      toolbar={pageToolbar}
+      scrollToTop
+      gap='only-top'
+    >
+      {error != null ? (
+        <EmptyState
+          title='Not authorized'
+          action={
+            <Link href={goBackUrl}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      ) : (
+        <>
+          <SkeletonTemplate isLoading={isLoading}>
+            <Spacer bottom='4'>
+              {!isMockedId(bundle.id) && (
+                <Spacer top='6'>
+                  <ResourceTags
+                    resourceType='bundles'
+                    resourceId={bundle.id}
+                    overlay={{ title: 'Edit tags', description: pageTitle }}
+                    onTagClick={(tagId) => {
+                      setLocation(
+                        appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
+                      )
+                    }}
+                  />
+                </Spacer>
+              )}
+              <Spacer top='14'>
+                <BundleDescription bundle={bundle} />
+              </Spacer>
+              <Spacer top='14'>
+                <BundleSkuList bundle={bundle} />
+              </Spacer>
+              <Spacer top='14'>
+                <BundleInfo bundle={bundle} />
+              </Spacer>
+              {!isMockedId(bundle.id) && (
+                <Spacer top='14'>
+                  <ResourceMetadata
+                    resourceType='bundles'
+                    resourceId={bundle.id}
+                    overlay={{
+                      title: bundle.name,
+                      description: bundle.code
+                    }}
+                  />
+                </Spacer>
+              )}
+            </Spacer>
+          </SkeletonTemplate>
+          {canUser('destroy', 'bundles') && (
+            <DeleteOverlay backgroundColor='light'>
+              <PageLayout
+                title={`Confirm that you want to delete the ${bundle.code} (${bundle.name}) bundle.`}
+                description='This action cannot be undone, proceed with caution.'
+                minHeight={false}
+                navigationButton={{
+                  onClick: () => {
+                    close()
+                  },
+                  label: `Cancel`,
+                  icon: 'x'
+                }}
+              >
+                <Button
+                  variant='danger'
+                  size='small'
+                  disabled={isDeleteting}
+                  onClick={(e) => {
+                    setIsDeleting(true)
+                    e.stopPropagation()
+                    void sdkClient.bundles
+                      .delete(bundle.id)
+                      .then(() => {
+                        setLocation(appRoutes.list.makePath({}))
+                      })
+                      .catch(() => {})
+                  }}
+                  fullWidth
+                >
+                  Delete bundle
+                </Button>
+              </PageLayout>
+            </DeleteOverlay>
+          )}
+          {!isMockedId(bundle.id) && (
+            <EditMetadataOverlay
+              resourceType={bundle.type}
+              resourceId={bundle.id}
+              title={bundle.name}
+              description={bundle.code}
+            />
+          )}
+        </>
+      )}
+    </PageLayout>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.3.0
-        version: 2.3.0(@commercelayer/sdk@6.14.1)(query-string@9.1.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.3.3
+        version: 2.3.3(@commercelayer/sdk@6.14.1)(query-string@9.1.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
         specifier: 6.14.1
         version: 6.14.1
@@ -1500,6 +1500,18 @@ packages:
 
   '@commercelayer/app-elements@2.3.0':
     resolution: {integrity: sha512-2zPuLORqNAgpuQjfAfv1R8Qlr0aMDMjR97P3f4Ij7KRMTqCe4gxaW8WoMQRWlt6h6PHADNdx31CCbi0dVGCR6w==}
+    engines: {node: '>=18', pnpm: '>=7'}
+    peerDependencies:
+      '@commercelayer/sdk': ^6.x
+      query-string: ^8.2.x
+      react: ^18.2.x
+      react-dom: ^18.2.x
+      react-gtm-module: ^2.x
+      react-hook-form: ^7.50.x
+      wouter: ^3.x
+
+  '@commercelayer/app-elements@2.3.3':
+    resolution: {integrity: sha512-R29T0wM8pYzw+v7I0nObUfQ/J1i7X8AuwvTlDMP/w8lPyTlXGK3PunGRkco67Ct2tH8cAvKKaEcb4XsXwZvyAw==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -4766,6 +4778,12 @@ packages:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
 
+  react-tooltip@5.28.0:
+    resolution: {integrity: sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -5291,9 +5309,6 @@ packages:
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
-  tslib@2.6.3:
-    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -5890,6 +5905,34 @@ snapshots:
       react-hook-form: 7.53.0(react@18.3.1)
       react-select: 5.8.0(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-tooltip: 5.27.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr: 2.2.5(react@18.3.1)
+      ts-invariant: 0.10.3
+      type-fest: 4.26.0
+      wouter: 3.3.5(react@18.3.1)
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@commercelayer/app-elements@2.3.3(@commercelayer/sdk@6.14.1)(query-string@9.1.0)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))':
+    dependencies:
+      '@commercelayer/sdk': 6.14.1
+      '@types/lodash': 4.17.7
+      '@types/react': 18.3.5
+      '@types/react-datepicker': 6.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react-dom': 18.3.0
+      classnames: 2.5.1
+      jwt-decode: 4.0.0
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      query-string: 9.1.0
+      react: 18.3.1
+      react-currency-input-field: 3.8.0(react@18.3.1)
+      react-datepicker: 7.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-gtm-module: 2.0.11
+      react-hook-form: 7.53.0(react@18.3.1)
+      react-select: 5.8.0(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-tooltip: 5.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       swr: 2.2.5(react@18.3.1)
       ts-invariant: 0.10.3
       type-fest: 4.26.0
@@ -9670,6 +9713,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  react-tooltip@5.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@floating-ui/dom': 1.6.1
+      classnames: 2.5.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.25.6
@@ -10220,7 +10270,7 @@ snapshots:
 
   ts-invariant@0.10.3:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.7.0
 
   tsconfck@3.0.3(typescript@5.5.4):
     optionalDependencies:
@@ -10240,8 +10290,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.6.2: {}
-
-  tslib@2.6.3: {}
 
   tslib@2.7.0: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added the bundle detail page to `bundles` app.

This new page shows:
- Infos about the bundle product like `name`, `code`, `description`, `image_url`, `market`, `prices`
- The list of the SKU list items that are inside the related SKU List (it must be a manual SKU List)

<img width="500" alt="Screenshot 2024-09-09 alle 16 03 26" src="https://github.com/user-attachments/assets/4cf540a7-a5da-4498-a42e-1443f6b2e659">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
