### PR TITLE
Show proper updated_at date when display pending order details

### DIFF
--- a/apps/orders/src/pages/OrderDetails.tsx
+++ b/apps/orders/src/pages/OrderDetails.tsx
@@ -159,7 +159,7 @@ function OrderDetails(): JSX.Element {
             <div>
               {formatDateWithPredicate({
                 predicate: 'Updated',
-                isoDate: order.placed_at ?? '',
+                isoDate: order.updated_at ?? '',
                 timezone: user?.timezone
               })}
             </div>


### PR DESCRIPTION
## What I did

This PR fixes the updated at date not showing on pending order details

was:
<img width="303" alt="image" src="https://github.com/user-attachments/assets/9d3b00ee-875b-4448-a5d4-105d41bda8d7">


now:
<img width="299" alt="image" src="https://github.com/user-attachments/assets/ee98d79e-ed11-42dd-bef0-038cb85b3c72">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
