### PR TITLE
Enforce `market` and `currency` selctors in bundle form

### DIFF
--- a/apps/bundles/src/components/BundleForm.tsx
+++ b/apps/bundles/src/components/BundleForm.tsx
@@ -211,6 +211,7 @@ export function BundleForm({
               defaultMarketId={defaultValues?.market ?? ''}
               defaultCurrencyCode={defaultValues?.currency_code ?? 'USD'}
               hint='The market where this bundle is available.'
+              isDisabled={defaultValues?.id != null}
             />
           </Spacer>
           <Spacer top='6'>

--- a/apps/bundles/src/components/MarketWithCurrencySelector.tsx
+++ b/apps/bundles/src/components/MarketWithCurrencySelector.tsx
@@ -4,6 +4,7 @@ import {
   HookedInputSelect,
   useCoreApi,
   useCoreSdkProvider,
+  type HookedInputSelectProps,
   type InputSelectValue
 } from '@commercelayer/app-elements'
 import {
@@ -25,7 +26,8 @@ export const MarketWithCurrencySelector: FC<{
   defaultMarketId: string
   defaultCurrencyCode: string
   hint: string
-}> = ({ defaultMarketId, defaultCurrencyCode, hint }) => {
+  isDisabled?: HookedInputSelectProps['isDisabled']
+}> = ({ defaultMarketId, defaultCurrencyCode, hint, isDisabled = false }) => {
   const { sdkClient } = useCoreSdkProvider()
   const { watch, setValue } = useFormContext()
   const { data, isLoading: isLoadingInitialValues } = useCoreApi(
@@ -96,6 +98,7 @@ export const MarketWithCurrencySelector: FC<{
           isLoading={isLoadingInitialValues || isLoadingDefaultResource}
           isClearable={false}
           isSearchable
+          isDisabled={isDisabled}
           initialValues={initialValues}
           onSelect={(selected) => {
             const relatedCurrencyCode = flatSelectValues(
@@ -148,6 +151,7 @@ export const MarketWithCurrencySelector: FC<{
         <HookedInputSelect
           name='currency_code'
           label='&nbsp;'
+          isDisabled={isDisabled}
           initialValues={currencyInputSelectOptions}
         />
       )}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I enforced `market` and `currency` selctor in `bundle` form to avoid the fields to be changed if the resource is being edited.

<img width="500" alt="Screenshot 2024-09-13 alle 19 54 53" src="https://github.com/user-attachments/assets/1d0c1881-ccc2-41b2-af91-af78111d177a">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
