### PR TITLE
Enforce `SKU list` app

### DIFF
--- a/apps/sku_lists/src/components/SkuListForm/SkuListForm.tsx
+++ b/apps/sku_lists/src/components/SkuListForm/SkuListForm.tsx
@@ -41,6 +41,7 @@ interface Props {
     setError: UseFormSetError<SkuListFormValues>
   ) => void
   apiError?: any
+  hasBundles?: boolean
 }
 
 export function SkuListForm({
@@ -48,7 +49,8 @@ export function SkuListForm({
   defaultValues,
   onSubmit,
   apiError,
-  isSubmitting
+  isSubmitting,
+  hasBundles = false
 }: Props): JSX.Element {
   const { skuListItems } = useSkuListItems(resource?.id ?? '')
   const skuListFormMethods = useForm<SkuListFormValues>({
@@ -118,109 +120,111 @@ export function SkuListForm({
               hint={{ text: 'Pick a name that helps you identify it.' }}
             />
           </Spacer>
-          <Spacer top='12' bottom='4'>
-            <Tabs
-              onTabSwitch={handleOnTabSwitch}
-              keepAlive
-              defaultTab={defaultTab}
-            >
-              <Tab name='Manual'>
-                {watchedFormItems?.map((item) => (
-                  <Spacer top='2' key={item.sku_code}>
-                    <ListItemCardSkuListItem
-                      resource={item}
-                      onQuantityChange={(resource, quantity) => {
-                        const updatedSelectedItems: FormSkuListItem[] = []
-                        watchedFormItems.forEach((item) => {
-                          if (item.sku_code === resource.sku_code) {
-                            item.quantity = quantity
-                          }
-                          updatedSelectedItems.push(item)
-                        })
-                        skuListFormMethods.setValue(
-                          'items',
-                          updatedSelectedItems
-                        )
-                      }}
-                      onRemoveClick={(resource) => {
-                        const updatedSelectedItems: FormSkuListItem[] = []
-                        watchedFormItems.forEach((item) => {
-                          if (item.sku_code !== resource.sku_code) {
+          {!hasBundles && (
+            <Spacer top='12' bottom='4'>
+              <Tabs
+                onTabSwitch={handleOnTabSwitch}
+                keepAlive
+                defaultTab={defaultTab}
+              >
+                <Tab name='Manual'>
+                  {watchedFormItems?.map((item) => (
+                    <Spacer top='2' key={item.sku_code}>
+                      <ListItemCardSkuListItem
+                        resource={item}
+                        onQuantityChange={(resource, quantity) => {
+                          const updatedSelectedItems: FormSkuListItem[] = []
+                          watchedFormItems.forEach((item) => {
+                            if (item.sku_code === resource.sku_code) {
+                              item.quantity = quantity
+                            }
                             updatedSelectedItems.push(item)
-                          }
-                        })
-                        skuListFormMethods.setValue(
-                          'items',
-                          updatedSelectedItems
-                        )
+                          })
+                          skuListFormMethods.setValue(
+                            'items',
+                            updatedSelectedItems
+                          )
+                        }}
+                        onRemoveClick={(resource) => {
+                          const updatedSelectedItems: FormSkuListItem[] = []
+                          watchedFormItems.forEach((item) => {
+                            if (item.sku_code !== resource.sku_code) {
+                              updatedSelectedItems.push(item)
+                            }
+                          })
+                          skuListFormMethods.setValue(
+                            'items',
+                            updatedSelectedItems
+                          )
+                        }}
+                      />
+                    </Spacer>
+                  ))}
+                  <Spacer top='2'>
+                    <Button
+                      type='button'
+                      variant='relationship'
+                      fullWidth
+                      onClick={() => {
+                        showAddItemOverlay(selectedItemsCodes)
                       }}
-                    />
+                    >
+                      Add item
+                    </Button>
                   </Spacer>
-                ))}
-                <Spacer top='2'>
-                  <Button
-                    type='button'
-                    variant='relationship'
-                    fullWidth
-                    onClick={() => {
-                      showAddItemOverlay(selectedItemsCodes)
-                    }}
-                  >
-                    Add item
-                  </Button>
-                </Spacer>
-                <Spacer top='2'>
-                  <HookedValidationError name='items' />
-                </Spacer>
-                <AddItemOverlay
-                  onConfirm={(selectedSku) => {
-                    const selectedItems =
-                      skuListFormMethods.getValues('items') ?? []
-                    if (
-                      selectedItems.find(
-                        (item) => item.sku_code === selectedSku.code
-                      ) == null
-                    ) {
-                      const newSkuListItem = {
-                        id: '',
-                        sku_code: selectedSku.code,
-                        quantity: 1,
-                        position: selectedItems.length + 1,
-                        sku: {
-                          id: selectedSku.id,
-                          code: selectedSku.code,
-                          name: selectedSku.name,
-                          image_url: selectedSku.image_url ?? undefined
+                  <Spacer top='2'>
+                    <HookedValidationError name='items' />
+                  </Spacer>
+                  <AddItemOverlay
+                    onConfirm={(selectedSku) => {
+                      const selectedItems =
+                        skuListFormMethods.getValues('items') ?? []
+                      if (
+                        selectedItems.find(
+                          (item) => item.sku_code === selectedSku.code
+                        ) == null
+                      ) {
+                        const newSkuListItem = {
+                          id: '',
+                          sku_code: selectedSku.code,
+                          quantity: 1,
+                          position: selectedItems.length + 1,
+                          sku: {
+                            id: selectedSku.id,
+                            code: selectedSku.code,
+                            name: selectedSku.name,
+                            image_url: selectedSku.image_url ?? undefined
+                          }
                         }
+                        selectedItems?.push(newSkuListItem)
+                        skuListFormMethods.setValue('items', selectedItems)
                       }
-                      selectedItems?.push(newSkuListItem)
-                      skuListFormMethods.setValue('items', selectedItems)
-                    }
-                  }}
-                />
-              </Tab>
-              <Tab name='Automatic'>
-                <HookedInputTextArea
-                  name='sku_code_regex'
-                  hint={{
-                    text: (
-                      <span>
-                        Use{' '}
-                        <a
-                          href='https://regex101.com/'
-                          target='_blank'
-                          rel='noreferrer'
-                        >
-                          regular expressions
-                        </a>{' '}
-                        for matching SKU codes, such as "AT | BE".
-                      </span>
-                    )
-                  }}
-                />
-              </Tab>
-            </Tabs>
-          </Spacer>
+                    }}
+                  />
+                </Tab>
+                <Tab name='Automatic'>
+                  <HookedInputTextArea
+                    name='sku_code_regex'
+                    hint={{
+                      text: (
+                        <span>
+                          Use{' '}
+                          <a
+                            href='https://regex101.com/'
+                            target='_blank'
+                            rel='noreferrer'
+                          >
+                            regular expressions
+                          </a>{' '}
+                          for matching SKU codes, such as "AT | BE".
+                        </span>
+                      )
+                    }}
+                  />
+                </Tab>
+              </Tabs>
+            </Spacer>
+          )}
         </Section>
         <Spacer top='14'>
           <Button type='submit' disabled={isSubmitting} fullWidth>

--- a/apps/sku_lists/src/hooks/useSkuListDetails.tsx
+++ b/apps/sku_lists/src/hooks/useSkuListDetails.tsx
@@ -14,9 +14,14 @@ export function useSkuListDetails(id: string): {
     isLoading,
     error,
     mutate: mutateSkuList
-  } = useCoreApi('sku_lists', 'retrieve', isMockedId(id) ? null : [id], {
-    fallbackData: makeSkuList()
-  })
+  } = useCoreApi(
+    'sku_lists',
+    'retrieve',
+    isMockedId(id) ? null : [id, { include: ['bundles'] }],
+    {
+      fallbackData: makeSkuList()
+    }
+  )
 
   return { skuList, error, isLoading, mutateSkuList }
 }

--- a/apps/sku_lists/src/pages/SkuListDetails.tsx
+++ b/apps/sku_lists/src/pages/SkuListDetails.tsx
@@ -7,6 +7,7 @@ import {
   Section,
   SkeletonTemplate,
   Spacer,
+  Text,
   goBack,
   useCoreSdkProvider,
   useOverlay,
@@ -68,6 +69,10 @@ export const SkuListDetails = (
 
   const pageTitle = skuList?.name
   const hasBundles = skuList?.bundles != null && skuList?.bundles.length > 0
+  const isManual =
+    skuList?.manual === true && skuListItems != null && skuListItems.length > 0
+  const isAutomatic =
+    skuList?.manual === false && skuList.sku_code_regex != null
 
   const pageToolbar: PageHeadingProps['toolbar'] = {
     buttons: [],
@@ -136,18 +141,11 @@ export const SkuListDetails = (
         )}
         <Spacer top='12' bottom='4'>
           <Section title='Items'>
-            {skuList.manual === true ? (
-              <>
-                {skuListItems != null
-                  ? skuListItems.map((item) => (
-                      <ListItemSkuListItem
-                        key={item.sku_code}
-                        resource={item}
-                      />
-                    ))
-                  : null}
-              </>
-            ) : (
+            {isManual ? (
+              skuListItems.map((item) => (
+                <ListItemSkuListItem key={item.sku_code} resource={item} />
+              ))
+            ) : isAutomatic ? (
               <Spacer top='6'>
                 <CodeBlock
                   hint={{
@@ -156,6 +154,10 @@ export const SkuListDetails = (
                 >
                   {skuList.sku_code_regex ?? ''}
                 </CodeBlock>
+              </Spacer>
+            ) : (
+              <Spacer top='4'>
+                <Text variant='info'>No items.</Text>
               </Spacer>
             )}
           </Section>

--- a/apps/sku_lists/src/pages/SkuListDetails.tsx
+++ b/apps/sku_lists/src/pages/SkuListDetails.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   CodeBlock,
   EmptyState,
@@ -66,6 +67,7 @@ export const SkuListDetails = (
   }
 
   const pageTitle = skuList?.name
+  const hasBundles = skuList?.bundles != null && skuList?.bundles.length > 0
 
   const pageToolbar: PageHeadingProps['toolbar'] = {
     buttons: [],
@@ -125,6 +127,13 @@ export const SkuListDetails = (
       gap='only-top'
     >
       <SkeletonTemplate isLoading={isLoadingItems}>
+        {hasBundles && (
+          <Spacer top='12' bottom='4'>
+            <Alert status='info'>
+              Items in a SKU List linked to a Bundle cannot be modified.
+            </Alert>
+          </Spacer>
+        )}
         <Spacer top='12' bottom='4'>
           <Section title='Items'>
             {skuList.manual === true ? (

--- a/apps/sku_lists/src/pages/SkuListEdit.tsx
+++ b/apps/sku_lists/src/pages/SkuListEdit.tsx
@@ -20,6 +20,7 @@ export function SkuListEdit(): JSX.Element {
   const skuListId = params?.skuListId ?? ''
 
   const { skuList, isLoading, mutateSkuList } = useSkuListDetails(skuListId)
+  const hasBundles = skuList?.bundles != null && skuList?.bundles.length > 0
 
   const { updateSkuListError, updateSkuList, isUpdatingSkuList } =
     useUpdateSkuList()
@@ -89,6 +90,7 @@ export function SkuListEdit(): JSX.Element {
                 setLocation(goBackUrl)
               })
             }}
+            hasBundles={hasBundles}
           />
         ) : null}
       </Spacer>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforced `SKU list`  app to avoid `SKU list items` to be edited if `SKU list` is linked to any `Bundle`.

<img width="600" alt="Screenshot 2024-09-19 alle 16 28 15" src="https://github.com/user-attachments/assets/b857d71d-ec9d-41d9-bb9e-f0091ada56b0">

If the `Edit` button is clicked the form will permit only to edit the `Name` field.

<img width="600" alt="Screenshot 2024-09-19 alle 16 45 29" src="https://github.com/user-attachments/assets/dddd6ce8-0e68-429e-a2bc-31ed123151a4">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
