### PR TITLE
Pre-default `*` operator for order text search (`aggregated_details`)

### DIFF
--- a/apps/orders/src/data/filters.ts
+++ b/apps/orders/src/data/filters.ts
@@ -156,7 +156,11 @@ export const makeInstructions = ({
     label: 'Search',
     type: 'textSearch',
     sdk: {
-      predicate: 'aggregated_details'
+      predicate: 'aggregated_details',
+      parseFormValue: (value) =>
+        typeof value === 'string' && value.trim()?.length > 0
+          ? `*${value.trim()}*`
+          : undefined
     },
     render: {
       component: 'searchBar'


### PR DESCRIPTION
## What I did

When using search bar on app-orders, every aggregated_details input is sent to the API with `*` as both prefix and suffix.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
