### PR TITLE
Add support for `upcoming` status in `Stock Transfers` app

### DIFF
--- a/apps/stock_transfers/src/data/dictionaries.ts
+++ b/apps/stock_transfers/src/data/dictionaries.ts
@@ -13,6 +13,7 @@ export function getStockTransferTriggerActions(
   stockTransfer: StockTransfer
 ): TriggerAction[] {
   switch (stockTransfer.status) {
+    case 'upcoming':
     case 'on_hold':
       return [
         { triggerAttribute: '_cancel', variant: 'secondary' },

--- a/apps/stock_transfers/src/data/filters.ts
+++ b/apps/stock_transfers/src/data/filters.ts
@@ -49,6 +49,7 @@ export const instructions: FiltersInstructions = [
     sdk: {
       predicate: 'status_in',
       defaultOptions: [
+        'upcoming',
         'picking',
         'in_transit',
         'completed',
@@ -62,6 +63,7 @@ export const instructions: FiltersInstructions = [
       props: {
         mode: 'multi',
         options: [
+          { value: 'upcoming', label: 'Upcoming' },
           { value: 'picking', label: 'Picking' },
           { value: 'in_transit', label: 'In transit' },
           { value: 'completed', label: 'Completed' },

--- a/apps/stock_transfers/src/data/lists.test.ts
+++ b/apps/stock_transfers/src/data/lists.test.ts
@@ -3,6 +3,7 @@ import { presets } from '#data/lists'
 describe('filtersByListType', () => {
   test('should have the correct keys', () => {
     expect(Object.keys(presets)).toEqual([
+      'upcoming',
       'on_hold',
       'picking',
       'in_transit',

--- a/apps/stock_transfers/src/data/lists.ts
+++ b/apps/stock_transfers/src/data/lists.ts
@@ -1,8 +1,18 @@
 import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 
-export type ListType = 'on_hold' | 'picking' | 'in_transit' | 'history'
+export type ListType =
+  | 'upcoming'
+  | 'on_hold'
+  | 'picking'
+  | 'in_transit'
+  | 'history'
 
 export const presets: Record<ListType, FormFullValues> = {
+  upcoming: {
+    status_in: ['upcoming'],
+    archived_at_null: 'show',
+    viewTitle: 'Upcoming'
+  },
   on_hold: {
     status_in: ['on_hold'],
     archived_at_null: 'show',

--- a/apps/stock_transfers/src/pages/Home.tsx
+++ b/apps/stock_transfers/src/pages/Home.tsx
@@ -24,6 +24,9 @@ export function Home(): JSX.Element {
     instructions
   })
 
+  const { data: counterUpcoming, isLoading: isLoadingUpcoming } =
+    useHomeCounter('upcoming')
+
   const { data: counterPicking, isLoading: isLoadingPicking } =
     useHomeCounter('picking')
 
@@ -34,7 +37,10 @@ export function Home(): JSX.Element {
     useHomeCounter('on_hold')
 
   const isLoadingCounters =
-    isLoadingPicking || isLoadingIntransit || isLoadingOnHold
+    isLoadingUpcoming ||
+    isLoadingPicking ||
+    isLoadingIntransit ||
+    isLoadingOnHold
 
   return (
     <HomePageLayout title='Stock transfers'>
@@ -50,6 +56,28 @@ export function Home(): JSX.Element {
       <SkeletonTemplate isLoading={isLoadingCounters}>
         <Spacer bottom='14'>
           <List title='Open'>
+            <Link
+              href={appRoutes.list.makePath(
+                {},
+                adapters.adaptFormValuesToUrlQuery({
+                  formValues: presets.upcoming
+                })
+              )}
+              asChild
+            >
+              <ListItem
+                icon={
+                  <StatusIcon name='check' background='orange' gap='small' />
+                }
+              >
+                <Text weight='semibold'>
+                  {presets.upcoming.viewTitle}{' '}
+                  {formatCounter(counterUpcoming?.meta.recordCount)}
+                </Text>
+                <Icon name='caretRight' />
+              </ListItem>
+            </Link>
+
             <Link
               href={appRoutes.list.makePath(
                 {},


### PR DESCRIPTION
Closes commercelayer/issues-app#220

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support for `upcoming` status in `Stock Transfers` app.

<img width="600" alt="Screenshot 2024-09-25 alle 12 52 19" src="https://github.com/user-attachments/assets/eacf9cd0-a353-4955-b8f3-68069abf2d47">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [  ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
