### PR TITLE
Improve `SKU list` items list

### DIFF
--- a/apps/sku_lists/src/App.tsx
+++ b/apps/sku_lists/src/App.tsx
@@ -4,6 +4,7 @@ import { LinkEdit } from '#pages/LinkEdit'
 import { LinkNew } from '#pages/LinkNew'
 import { SkuListDetails } from '#pages/SkuListDetails'
 import { SkuListEdit } from '#pages/SkuListEdit'
+import SkuListItemsList from '#pages/SkuListItemsList'
 import { SkuListNew } from '#pages/SkuListNew'
 import { SkuListsList } from '#pages/SkuListsList'
 import type { FC } from 'react'
@@ -27,6 +28,7 @@ export const App: FC<AppProps> = ({ routerBase }) => {
         <Route path={appRoutes.new.path} component={SkuListNew} />
         <Route path={appRoutes.linksNew.path} component={LinkNew} />
         <Route path={appRoutes.linksDetails.path} component={LinkDetails} />
+        <Route path={appRoutes.itemsList.path} component={SkuListItemsList} />
         <Route path={appRoutes.linksEdit.path} component={LinkEdit} />
         <Route>
           <ErrorNotFound />

--- a/apps/sku_lists/src/data/routes.ts
+++ b/apps/sku_lists/src/data/routes.ts
@@ -26,6 +26,9 @@ export const appRoutes = {
   details: createTypedRoute<{ skuListId: SkuList['id'] }>()(
     '/list/:skuListId/'
   ),
+  itemsList: createTypedRoute<{ skuListId: SkuList['id'] }>()(
+    '/list/:skuListId/items/'
+  ),
   edit: createTypedRoute<{ skuListId: SkuList['id'] }>()(
     '/list/:skuListId/edit/'
   ),

--- a/apps/sku_lists/src/hooks/useSkuListItems.tsx
+++ b/apps/sku_lists/src/hooks/useSkuListItems.tsx
@@ -4,6 +4,7 @@ import type { SkuListItem } from '@commercelayer/sdk'
 
 export function useSkuListItems(id: string): {
   skuListItems?: SkuListItem[]
+  skuListItemsCount?: number
   isLoadingItems: boolean
 } {
   const pauseRequest = isMockedId(id) || id === ''
@@ -19,10 +20,14 @@ export function useSkuListItems(id: string): {
             sort: {
               position: 'asc'
             },
-            pageSize: 25
+            pageSize: 5
           }
         ]
   )
 
-  return { skuListItems, isLoadingItems }
+  return {
+    skuListItems,
+    skuListItemsCount: skuListItems?.recordCount,
+    isLoadingItems
+  }
 }

--- a/apps/sku_lists/src/pages/SkuListDetails.tsx
+++ b/apps/sku_lists/src/pages/SkuListDetails.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   CodeBlock,
   EmptyState,
+  Icon,
   PageLayout,
   Section,
   SkeletonTemplate,
@@ -35,7 +36,8 @@ export const SkuListDetails = (
   const skuListId = props.params?.skuListId ?? ''
 
   const { skuList, isLoading, error } = useSkuListDetails(skuListId)
-  const { skuListItems, isLoadingItems } = useSkuListItems(skuListId)
+  const { skuListItems, skuListItemsCount, isLoadingItems } =
+    useSkuListItems(skuListId)
 
   const { sdkClient } = useCoreSdkProvider()
 
@@ -150,11 +152,32 @@ export const SkuListDetails = (
           </Spacer>
         )}
         <Spacer top='12' bottom='4'>
-          <Section title='Items'>
+          <Section
+            title={`Items · ${skuListItemsCount}`}
+            actionButton={
+              isManual &&
+              Number(skuListItemsCount) > 5 && (
+                <Button
+                  variant='secondary'
+                  size='mini'
+                  onClick={() => {
+                    setLocation(appRoutes.itemsList.makePath({ skuListId }))
+                  }}
+                  alignItems='center'
+                >
+                  <Icon name='eye' size={16} />
+                  See all
+                </Button>
+              )
+            }
+          >
             {isManual ? (
-              skuListItems.map((item) => (
-                <ListItemSkuListItem key={item.sku_code} resource={item} />
-              ))
+              <>
+                {skuListItems.map((item) => (
+                  <ListItemSkuListItem key={item.sku_code} resource={item} />
+                ))}
+                {}
+              </>
             ) : isAutomatic ? (
               <Spacer top='6'>
                 <CodeBlock

--- a/apps/sku_lists/src/pages/SkuListItemsList.tsx
+++ b/apps/sku_lists/src/pages/SkuListItemsList.tsx
@@ -1,0 +1,81 @@
+import { ListItemSkuListItem } from '#components/ListItemSkuListItem'
+import { appRoutes } from '#data/routes'
+import { useSkuListDetails } from '#hooks/useSkuListDetails'
+import {
+  EmptyState,
+  PageLayout,
+  ResourceList,
+  SearchBar,
+  Spacer,
+  useTokenProvider,
+  type PageProps
+} from '@commercelayer/app-elements'
+import { useState } from 'react'
+import { useLocation } from 'wouter'
+
+function SkuListItemsList(
+  props: PageProps<typeof appRoutes.itemsList>
+): JSX.Element {
+  const {
+    settings: { mode }
+  } = useTokenProvider()
+  const [, setLocation] = useLocation()
+  const [searchValue, setSearchValue] = useState<string>()
+  const { skuList } = useSkuListDetails(props.params.skuListId)
+
+  return (
+    <PageLayout
+      overlay={props.overlay}
+      title='All items'
+      mode={mode}
+      gap='only-top'
+      navigationButton={{
+        label: skuList.name,
+        icon: 'arrowLeft',
+        onClick() {
+          setLocation(
+            appRoutes.details.makePath({
+              skuListId: props.params.skuListId
+            })
+          )
+        }
+      }}
+    >
+      <Spacer top='4'>
+        <SearchBar
+          initialValue={searchValue}
+          onSearch={setSearchValue}
+          placeholder='Search...'
+          onClear={() => {
+            setSearchValue('')
+          }}
+        />
+      </Spacer>
+
+      <Spacer top='14'>
+        <ResourceList
+          title='Results'
+          type='sku_list_items'
+          query={{
+            filters: {
+              sku_list_id_eq: props.params.skuListId,
+              ...(searchValue != null ? { sku_name_cont: searchValue } : {})
+            },
+            include: ['sku'],
+            sort: ['position']
+          }}
+          ItemTemplate={ListItemSkuListItem}
+          emptyState={
+            <EmptyState
+              title='No items found!'
+              icon='shield'
+              description='No markets found for this SKU list.'
+            />
+          }
+        />
+      </Spacer>
+    </PageLayout>
+  )
+}
+
+export default SkuListItemsList


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/221

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The items shown inside the SKU List detail page will now be limited to `5` with the introduction of the `See all` button on the top right of the `Items` section to view a searchable full list relying on infinite loading.

<img width="500" alt="Screenshot 2024-09-26 alle 13 23 26" src="https://github.com/user-attachments/assets/c4c1de2e-01ff-46bf-874c-7511dbd33db1">

<img width="500" alt="Screenshot 2024-09-26 alle 13 23 33" src="https://github.com/user-attachments/assets/3d29a0de-94e7-4d55-a395-e13062997baf">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
