### PR TITLE
Fix attachment creation in `Stock transfers` app

### DIFF
--- a/apps/stock_transfers/src/components/StockTransferTimeline.tsx
+++ b/apps/stock_transfers/src/components/StockTransferTimeline.tsx
@@ -1,4 +1,4 @@
-import { referenceOrigins } from '#data/attachments'
+import { isAttachmentValidNote, referenceOrigins } from '#data/attachments'
 import { isMockedId } from '#mocks'
 import {
   Section,
@@ -14,7 +14,13 @@ import {
 
 import type { Attachment, StockTransfer } from '@commercelayer/sdk'
 import isEmpty from 'lodash/isEmpty'
-import { useEffect, useReducer, useState, type Reducer } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useReducer,
+  useState,
+  type Reducer
+} from 'react'
 
 export const StockTransferTimeline = withSkeletonTemplate<{
   stockTransferId?: string
@@ -42,7 +48,12 @@ export const StockTransferTimeline = withSkeletonTemplate<{
         isEmpty(stockTransferId) ||
         isMockedId(stockTransferId)
         ? null
-        : [stockTransferId],
+        : [
+            stockTransferId,
+            {
+              include: ['attachments']
+            }
+          ],
       {
         fallbackData: {
           type: 'stock_transfers',
@@ -222,6 +233,38 @@ const useTimelineReducer = (stockTransfer: StockTransfer) => {
       }
     },
     [stockTransfer.cancelled_at]
+  )
+
+  const dispatchAttachments = useCallback(
+    (attachments?: Attachment[] | null | undefined) => {
+      if (attachments != null) {
+        attachments.forEach((attachment) => {
+          if (
+            isAttachmentValidNote(attachment, [
+              referenceOrigins.appStockTransfersNote
+            ])
+          ) {
+            dispatch({
+              type: 'add',
+              payload: {
+                date: attachment.updated_at,
+                author: attachment.name,
+                message: <span>left a note</span>,
+                note: attachment.description
+              }
+            })
+          }
+        })
+      }
+    },
+    []
+  )
+
+  useEffect(
+    function addAttachments() {
+      dispatchAttachments(stockTransfer.attachments)
+    },
+    [stockTransfer.attachments]
   )
 
   return [events, dispatch] as const

--- a/apps/stock_transfers/src/components/StockTransferTimeline.tsx
+++ b/apps/stock_transfers/src/components/StockTransferTimeline.tsx
@@ -105,7 +105,10 @@ export const StockTransferTimeline = withSkeletonTemplate<{
                     reference_origin: attachmentOption.referenceOrigin,
                     name: user.displayName,
                     description: event.currentTarget.value,
-                    attachable: { type: 'returns', id: stockTransfer.id }
+                    attachable: {
+                      type: 'stock_transfers',
+                      id: stockTransfer.id
+                    }
                   })
                   .then((attachment) => {
                     void mutateStockTransfer()


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fix attachment creation in `Stock transfers` app by setting the correct resource type used to create the `attachment` and by adding the missing visualization of the attachments in the list.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
