### PR TITLE
Show whether taxes are included or not in the order summary

### DIFF
--- a/apps/orders/src/components/OrderSummary/SummaryRows.tsx
+++ b/apps/orders/src/components/OrderSummary/SummaryRows.tsx
@@ -134,7 +134,14 @@ export const SummaryRows: React.FC<{ order: Order; editable: boolean }> = ({
         formattedAmount: order.formatted_payment_method_amount
       })}
       {renderTotalRowAmount({
-        label: 'Taxes',
+        label: (
+          <>
+            Taxes
+            <Text variant='info'>
+              {order.tax_included === true ? ' (included)' : ''}
+            </Text>
+          </>
+        ),
         amountCents: order.total_tax_amount_cents,
         formattedAmount: order.formatted_total_tax_amount
       })}

--- a/apps/orders/src/components/OrderSummary/utils.tsx
+++ b/apps/orders/src/components/OrderSummary/utils.tsx
@@ -4,7 +4,7 @@ import { Fragment } from 'react'
 
 interface TotalRowProps {
   /** Displayed label */
-  label: string
+  label: React.ReactNode
   /** Amount cents */
   amountCents: number | undefined | null
   /** Formatted amount */
@@ -24,7 +24,7 @@ export function renderTotalRow({
   value,
   bold = false
 }: {
-  label: string
+  label: React.ReactNode
   value: React.ReactNode
   bold?: boolean
 }): JSX.Element {


### PR DESCRIPTION
## What I did

Show whether taxes are included or not in the order summary.

<img width="686" alt="screenshot showing the result" src="https://github.com/user-attachments/assets/90440edb-c03e-4a19-aa0a-b591554f64e2">
