### PR TITLE
Fix spacings in some details pages

### DIFF
--- a/apps/bundles/src/pages/BundleDetails.tsx
+++ b/apps/bundles/src/pages/BundleDetails.tsx
@@ -107,7 +107,7 @@ export const BundleDetails: FC = () => {
         <>
           <SkeletonTemplate isLoading={isLoading}>
             <Spacer bottom='4'>
-              <Spacer top='6'>
+              <Spacer top='14'>
                 <BundleDescription bundle={bundle} />
               </Spacer>
               <Spacer top='14'>

--- a/apps/orders/src/pages/OrderDetails.tsx
+++ b/apps/orders/src/pages/OrderDetails.tsx
@@ -150,7 +150,7 @@ function OrderDetails(): JSX.Element {
     >
       <SkeletonTemplate isLoading={isLoading}>
         <Spacer bottom='4'>
-          <Spacer top='6'>
+          <Spacer top='14'>
             <OrderSteps order={order} />
           </Spacer>
           <Spacer top='14'>

--- a/apps/shipments/src/pages/ShipmentDetails.tsx
+++ b/apps/shipments/src/pages/ShipmentDetails.tsx
@@ -113,7 +113,7 @@ export function ShipmentDetails(): JSX.Element {
       <SkeletonTemplate isLoading={isLoading}>
         <pageToolbar.Components />
         <Spacer bottom='4'>
-          <Spacer top='6'>
+          <Spacer top='14'>
             <ShipmentSteps shipment={shipment} />
           </Spacer>
           <Spacer top='14'>

--- a/apps/skus/src/pages/SkuDetails.tsx
+++ b/apps/skus/src/pages/SkuDetails.tsx
@@ -143,7 +143,7 @@ export const SkuDetails: FC = () => {
     >
       <SkeletonTemplate isLoading={isLoading}>
         <Spacer bottom='4'>
-          <Spacer top='6'>
+          <Spacer top='14'>
             <SkuDescription sku={sku} />
           </Spacer>
           <Spacer top='14'>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Readapt top spacing of details pages in some app where the `ResourceTags` component was moved at the bottom.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
