### PR TITLE
Reorganize `SKUs` app detail page with tabs

### DIFF
--- a/apps/skus/src/pages/LinkDetails.tsx
+++ b/apps/skus/src/pages/LinkDetails.tsx
@@ -7,7 +7,7 @@ export const LinkDetails = (
   const skuId = props.params?.resourceId ?? ''
   const linkId = props.params?.linkId ?? ''
 
-  const goBackUrl = appRoutes.details.makePath({ skuId })
+  const goBackUrl = `${appRoutes.details.makePath({ skuId })}?tab=links`
 
   return <LinkDetailsPage linkId={linkId} goBackUrl={goBackUrl} />
 }

--- a/apps/skus/src/pages/LinkEdit.tsx
+++ b/apps/skus/src/pages/LinkEdit.tsx
@@ -8,7 +8,7 @@ export function LinkEdit(
   const skuId = props.params?.resourceId ?? ''
   const linkId = props.params?.linkId ?? ''
 
-  const goBackUrl = appRoutes.details.makePath({ skuId })
+  const goBackUrl = `${appRoutes.details.makePath({ skuId })}?tab=links`
 
   return (
     <LinkEditPage

--- a/apps/skus/src/pages/LinkNew.tsx
+++ b/apps/skus/src/pages/LinkNew.tsx
@@ -8,7 +8,8 @@ export function LinkNew(
   props: PageProps<typeof appRoutes.linksNew>
 ): JSX.Element {
   const skuId = props.params?.resourceId ?? ''
-  const goBackUrl = appRoutes.details.makePath({ skuId })
+  const goBackUrl = `${appRoutes.details.makePath({ skuId })}?tab=links`
+
   const { sku, isLoading } = useSkuDetails(skuId)
   const defaultName =
     isLoading || isMockedId(sku.id) ? '' : `Link to ${sku.name}.`

--- a/apps/skus/src/pages/LinkNew.tsx
+++ b/apps/skus/src/pages/LinkNew.tsx
@@ -11,8 +11,7 @@ export function LinkNew(
   const goBackUrl = `${appRoutes.details.makePath({ skuId })}?tab=links`
 
   const { sku, isLoading } = useSkuDetails(skuId)
-  const defaultName =
-    isLoading || isMockedId(sku.id) ? '' : `Link to ${sku.name}.`
+  const defaultName = isLoading || isMockedId(sku.id) ? '' : sku.name
 
   return (
     <LinkNewPage

--- a/apps/skus/src/pages/SkuDetails.tsx
+++ b/apps/skus/src/pages/SkuDetails.tsx
@@ -139,6 +139,39 @@ export const SkuDetails: FC = () => {
           </Spacer>
           <Spacer top='14'>
             <Tabs keepAlive>
+              <Tab name='Info'>
+                <Spacer top='10'>
+                  <SkuInfo sku={sku} />
+                </Spacer>
+                <Spacer top='14'>
+                  <ResourceDetails resource={sku} />
+                </Spacer>
+                {!isMockedId(sku.id) && (
+                  <>
+                    <Spacer top='14'>
+                      <ResourceTags
+                        resourceType='skus'
+                        resourceId={sku.id}
+                        overlay={{ title: pageTitle }}
+                        onTagClick={(tagId) => {
+                          setLocation(
+                            appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
+                          )
+                        }}
+                      />
+                    </Spacer>
+                    <Spacer top='14'>
+                      <ResourceMetadata
+                        resourceType='skus'
+                        resourceId={sku.id}
+                        overlay={{
+                          title: pageTitle
+                        }}
+                      />
+                    </Spacer>
+                  </>
+                )}
+              </Tab>
               {showLinks ? (
                 <Tab name='Links'>
                   <Spacer top='10'>
@@ -175,39 +208,6 @@ export const SkuDetails: FC = () => {
                   </Spacer>
                 </Tab>
               ) : null}
-              <Tab name='Info'>
-                <Spacer top='10'>
-                  <SkuInfo sku={sku} />
-                </Spacer>
-                <Spacer top='14'>
-                  <ResourceDetails resource={sku} />
-                </Spacer>
-                {!isMockedId(sku.id) && (
-                  <>
-                    <Spacer top='14'>
-                      <ResourceTags
-                        resourceType='skus'
-                        resourceId={sku.id}
-                        overlay={{ title: pageTitle }}
-                        onTagClick={(tagId) => {
-                          setLocation(
-                            appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
-                          )
-                        }}
-                      />
-                    </Spacer>
-                    <Spacer top='14'>
-                      <ResourceMetadata
-                        resourceType='skus'
-                        resourceId={sku.id}
-                        overlay={{
-                          title: pageTitle
-                        }}
-                      />
-                    </Spacer>
-                  </>
-                )}
-              </Tab>
             </Tabs>
           </Spacer>
         </Spacer>

--- a/apps/skus/src/pages/SkuDetails.tsx
+++ b/apps/skus/src/pages/SkuDetails.tsx
@@ -28,6 +28,7 @@ import { appRoutes } from '#data/routes'
 import { useSkuDetails } from '#hooks/useSkuDetails'
 import { isMockedId } from '#mocks'
 import { useState, type FC } from 'react'
+import { useSearch } from 'wouter/use-browser-location'
 
 export const SkuDetails: FC = () => {
   const {
@@ -82,6 +83,14 @@ export const SkuDetails: FC = () => {
 
   const showLinks =
     extras?.salesChannels != null && extras?.salesChannels.length > 0
+
+  const tabs = ['info', ...(showLinks ? ['links'] : [])]
+  const queryString = useSearch()
+  const urlParams = new URLSearchParams(queryString)
+  const defaultTab =
+    urlParams.get('tab') != null
+      ? (tabs.findIndex((t) => t === urlParams.get('tab')) ?? 0)
+      : 0
 
   if (canUser('update', 'skus')) {
     pageToolbar.buttons?.push({
@@ -138,7 +147,7 @@ export const SkuDetails: FC = () => {
             <SkuDescription sku={sku} />
           </Spacer>
           <Spacer top='14'>
-            <Tabs keepAlive>
+            <Tabs keepAlive defaultTab={defaultTab}>
               <Tab name='Info'>
                 <Spacer top='10'>
                   <SkuInfo sku={sku} />

--- a/apps/skus/src/pages/SkuDetails.tsx
+++ b/apps/skus/src/pages/SkuDetails.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   EmptyState,
+  Icon,
   PageLayout,
   ResourceDetails,
   ResourceMetadata,
@@ -8,6 +9,8 @@ import {
   Section,
   SkeletonTemplate,
   Spacer,
+  Tab,
+  Tabs,
   Text,
   goBack,
   useCoreSdkProvider,
@@ -81,18 +84,6 @@ export const SkuDetails: FC = () => {
     extras?.salesChannels != null && extras?.salesChannels.length > 0
 
   if (canUser('update', 'skus')) {
-    if (showLinks) {
-      pageToolbar.buttons?.push({
-        label: 'New link',
-        icon: 'lightning',
-        size: 'small',
-        variant: 'secondary',
-        onClick: () => {
-          setLocation(appRoutes.linksNew.makePath({ resourceId: skuId }))
-        }
-      })
-    }
-
     pageToolbar.buttons?.push({
       label: 'Edit',
       size: 'small',
@@ -147,50 +138,78 @@ export const SkuDetails: FC = () => {
             <SkuDescription sku={sku} />
           </Spacer>
           <Spacer top='14'>
-            <SkuInfo sku={sku} />
-          </Spacer>
-          {showLinks && (
-            <Spacer top='12' bottom='4'>
-              <Section
-                title='Links'
-                border={linkListTable != null ? 'none' : undefined}
-              >
-                {linkListTable ?? (
-                  <Spacer top='4'>
-                    <Text variant='info'>No items.</Text>
+            <Tabs keepAlive>
+              {showLinks ? (
+                <Tab name='Links'>
+                  <Spacer top='10'>
+                    <Section
+                      title='Links'
+                      border={linkListTable != null ? 'none' : undefined}
+                      actionButton={
+                        canUser('update', 'skus') &&
+                        showLinks && (
+                          <Button
+                            size='mini'
+                            variant='secondary'
+                            alignItems='center'
+                            onClick={() => {
+                              setLocation(
+                                appRoutes.linksNew.makePath({
+                                  resourceId: skuId
+                                })
+                              )
+                            }}
+                          >
+                            <Icon name='lightning' size={16} />
+                            New link
+                          </Button>
+                        )
+                      }
+                    >
+                      {linkListTable ?? (
+                        <Spacer top='4'>
+                          <Text variant='info'>No items.</Text>
+                        </Spacer>
+                      )}
+                    </Section>
                   </Spacer>
+                </Tab>
+              ) : null}
+              <Tab name='Info'>
+                <Spacer top='10'>
+                  <SkuInfo sku={sku} />
+                </Spacer>
+                <Spacer top='14'>
+                  <ResourceDetails resource={sku} />
+                </Spacer>
+                {!isMockedId(sku.id) && (
+                  <>
+                    <Spacer top='14'>
+                      <ResourceTags
+                        resourceType='skus'
+                        resourceId={sku.id}
+                        overlay={{ title: pageTitle }}
+                        onTagClick={(tagId) => {
+                          setLocation(
+                            appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
+                          )
+                        }}
+                      />
+                    </Spacer>
+                    <Spacer top='14'>
+                      <ResourceMetadata
+                        resourceType='skus'
+                        resourceId={sku.id}
+                        overlay={{
+                          title: pageTitle
+                        }}
+                      />
+                    </Spacer>
+                  </>
                 )}
-              </Section>
-            </Spacer>
-          )}
-          <Spacer top='14'>
-            <ResourceDetails resource={sku} />
+              </Tab>
+            </Tabs>
           </Spacer>
-          {!isMockedId(sku.id) && (
-            <>
-              <Spacer top='14'>
-                <ResourceTags
-                  resourceType='skus'
-                  resourceId={sku.id}
-                  overlay={{ title: pageTitle }}
-                  onTagClick={(tagId) => {
-                    setLocation(
-                      appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
-                    )
-                  }}
-                />
-              </Spacer>
-              <Spacer top='14'>
-                <ResourceMetadata
-                  resourceType='skus'
-                  resourceId={sku.id}
-                  overlay={{
-                    title: pageTitle
-                  }}
-                />
-              </Spacer>
-            </>
-          )}
         </Spacer>
       </SkeletonTemplate>
       {canUser('destroy', 'skus') && (

--- a/packages/common/src/components/LinkListRow.tsx
+++ b/packages/common/src/components/LinkListRow.tsx
@@ -43,38 +43,15 @@ export const LinkListRow = ({
     return <></>
   }
 
+  const linkName = `${link.name.substring(0, 30)}${link.name.length > 30 ? `...` : ''}`
   const linkStatus = getLinkStatus(link)
 
   return (
     <Tr>
       <Td>
-        <div
-          style={{
-            width: '210px',
-            overflow: 'hidden',
-            position: 'relative'
-          }}
-        >
-          <Button variant='link' onClick={onLinkDetailsClick}>
-            {link.name}
-          </Button>
-          <span
-            className='text-gray-500 font-semibold'
-            style={{ fontSize: '11px' }}
-          >
-            {link.url}
-          </span>
-          <span
-            style={{
-              position: 'absolute',
-              right: '0',
-              top: '0',
-              width: '26px',
-              height: '100%',
-              background: 'linear-gradient(to right, transparent 12px, white)'
-            }}
-          />
-        </div>
+        <Button variant='link' onClick={onLinkDetailsClick}>
+          {linkName}
+        </Button>
       </Td>
       <Td>
         <Tooltip

--- a/packages/common/src/components/LinkListRow.tsx
+++ b/packages/common/src/components/LinkListRow.tsx
@@ -48,10 +48,6 @@ export const LinkListRow = ({
   return (
     <Tr>
       <Td>
-        <Button variant='link' onClick={onLinkDetailsClick}>
-          {link.name}
-        </Button>
-
         <div
           style={{
             width: '210px',
@@ -59,6 +55,9 @@ export const LinkListRow = ({
             position: 'relative'
           }}
         >
+          <Button variant='link' onClick={onLinkDetailsClick}>
+            {link.name}
+          </Button>
           <span
             className='text-gray-500 font-semibold'
             style={{ fontSize: '11px' }}

--- a/packages/common/src/components/LinkListTable.tsx
+++ b/packages/common/src/components/LinkListTable.tsx
@@ -24,7 +24,6 @@ export const LinkListTable = ({
 
   return !isLoading && (links == null || links?.length === 0) ? null : (
     <Table
-      variant='boxed'
       thead={
         <Tr>
           <Th>Code</Th>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Reorganized `SKUs` app detail page with tabs by:
- Moving `Links` to a first dedicated tab along with the `New link` CTA button previously placed inside the top toolbar
- Adding a `Info` tab that contains all the other blocks like `Info`, `Details`, `Tags` and `Metadata`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
