### PR TITLE
Fix `SKUs` edit form

### DIFF
--- a/apps/skus/src/utils/getSkuFromFormValues.ts
+++ b/apps/skus/src/utils/getSkuFromFormValues.ts
@@ -29,7 +29,8 @@ export const getSkuFromFormValues = (
     description: formValues.description,
     image_url: formValues.imageUrl,
     shipping_category: {
-      id: formValues.shippingCategory ?? '',
+      // @ts-expect-error shipping_category.id must be nullable to support relation deletion
+      id: formValues.shippingCategory ?? null,
       type: 'shipping_categories',
       name: '',
       created_at: '',


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/244

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed `SKUs` edit form to send `shipping_category` relationship with the correct relationship value depending on if it is to be filled or it needs to be nullified

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
