### PR TITLE
Show `SKUs` tabs only when needed

### DIFF
--- a/apps/skus/src/components/SkuInfo.tsx
+++ b/apps/skus/src/components/SkuInfo.tsx
@@ -16,18 +16,14 @@ export const SkuInfo: FC<Props> = ({ sku = makeSku() }) => {
   return (
     <Section title='Info'>
       {sku.shipping_category != null && (
-        <ListDetailsItem
-          label='Shipping category'
-          childrenAlign='right'
-          gutter='none'
-        >
+        <ListDetailsItem label='Shipping category' gutter='none'>
           <Text tag='div' weight='semibold'>
             {sku.shipping_category?.name}
           </Text>
         </ListDetailsItem>
       )}
       {sku.weight != null && sku.weight > 0 ? (
-        <ListDetailsItem label='Weight' childrenAlign='right' gutter='none'>
+        <ListDetailsItem label='Weight' gutter='none'>
           <Text tag='div' weight='semibold'>
             {sku.weight}{' '}
             {sku.unit_of_weight != null
@@ -37,25 +33,21 @@ export const SkuInfo: FC<Props> = ({ sku = makeSku() }) => {
         </ListDetailsItem>
       ) : null}
       {sku.do_not_ship != null && sku.do_not_ship ? (
-        <ListDetailsItem label='Shipping' childrenAlign='right' gutter='none'>
+        <ListDetailsItem label='Shipping' gutter='none'>
           <Text tag='div' weight='semibold'>
             {sku.do_not_ship ? 'Do not ship' : ''}
           </Text>
         </ListDetailsItem>
       ) : null}
       {sku.do_not_track != null && sku.do_not_track ? (
-        <ListDetailsItem label='Tracking' childrenAlign='right' gutter='none'>
+        <ListDetailsItem label='Tracking' gutter='none'>
           <Text tag='div' weight='semibold'>
             {sku.do_not_track ? 'Do not track stock' : ''}
           </Text>
         </ListDetailsItem>
       ) : null}
       {sku.pieces_per_pack != null && sku.pieces_per_pack > 0 ? (
-        <ListDetailsItem
-          label='Pieces per pack'
-          childrenAlign='right'
-          gutter='none'
-        >
+        <ListDetailsItem label='Pieces per pack' gutter='none'>
           <Text tag='div' weight='semibold'>
             {sku.pieces_per_pack} {sku.pieces_per_pack > 1 ? 'pieces' : 'piece'}
           </Text>

--- a/apps/skus/src/hooks/useSkuDeleteOverlay.tsx
+++ b/apps/skus/src/hooks/useSkuDeleteOverlay.tsx
@@ -1,0 +1,66 @@
+import { appRoutes } from '#data/routes'
+import {
+  Button,
+  PageLayout,
+  useCoreSdkProvider,
+  useOverlay
+} from '@commercelayer/app-elements'
+import type { Sku } from '@commercelayer/sdk'
+import { useState } from 'react'
+import { useLocation } from 'wouter'
+
+interface OverlayHook {
+  show: () => void
+  Overlay: React.FC
+}
+
+export function useSkuDeleteOverlay(sku: Sku): OverlayHook {
+  const { Overlay: OverlayElement, open, close } = useOverlay()
+  const [, setLocation] = useLocation()
+
+  return {
+    show: () => {
+      open()
+    },
+    Overlay: () => {
+      const [isDeleting, setIsDeleting] = useState(false)
+      const { sdkClient } = useCoreSdkProvider()
+
+      return (
+        <OverlayElement backgroundColor='light'>
+          <PageLayout
+            title={`Confirm that you want to delete the ${sku.code} (${sku.name}) SKU.`}
+            description='This action cannot be undone, proceed with caution.'
+            minHeight={false}
+            navigationButton={{
+              onClick: () => {
+                close()
+              },
+              label: `Cancel`,
+              icon: 'x'
+            }}
+          >
+            <Button
+              variant='danger'
+              size='small'
+              disabled={isDeleting}
+              onClick={(e) => {
+                setIsDeleting(true)
+                e.stopPropagation()
+                void sdkClient.skus
+                  .delete(sku.id)
+                  .then(() => {
+                    setLocation(appRoutes.list.makePath({}))
+                  })
+                  .catch(() => {})
+              }}
+              fullWidth
+            >
+              Delete SKU
+            </Button>
+          </PageLayout>
+        </OverlayElement>
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Enhanced `SKU`s detail page to show  `SKUs` tabs only when needed
- Fixed the alignment of `SKUs` infos to default left as per design requirements

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
