### PR TITLE
Update all deps to latest major

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -34,7 +34,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/bundles/src/pages/BundleDetails.tsx
+++ b/apps/bundles/src/pages/BundleDetails.tsx
@@ -35,7 +35,7 @@ export const BundleDetails: FC = () => {
   const bundleId = params?.bundleId ?? ''
   const goBackUrl = appRoutes.list.makePath({})
 
-  const { bundle, isLoading, error } = useBundleDetails(bundleId)
+  const { bundle, isLoading, error, mutateBundle } = useBundleDetails(bundleId)
 
   const { sdkClient } = useCoreSdkProvider()
 
@@ -117,7 +117,12 @@ export const BundleDetails: FC = () => {
                 <BundleInfo bundle={bundle} />
               </Spacer>
               <Spacer top='14'>
-                <ResourceDetails resource={bundle} />
+                <ResourceDetails
+                  resource={bundle}
+                  onUpdated={async () => {
+                    void mutateBundle()
+                  }}
+                />
               </Spacer>
               {!isMockedId(bundle.id) && (
                 <>

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -33,7 +33,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/customers/src/pages/CustomerDetails.tsx
+++ b/apps/customers/src/pages/CustomerDetails.tsx
@@ -35,7 +35,8 @@ export function CustomerDetails(): JSX.Element {
 
   const customerId = params?.customerId ?? ''
 
-  const { customer, isLoading, error } = useCustomerDetails(customerId)
+  const { customer, isLoading, error, mutateCustomer } =
+    useCustomerDetails(customerId)
 
   const { DeleteOverlay, show } = useCustomerDeleteOverlay(customerId)
 
@@ -124,7 +125,12 @@ export function CustomerDetails(): JSX.Element {
               <CustomerAddresses customer={customer} />
             </Spacer>
             <Spacer top='14'>
-              <ResourceDetails resource={customer} />
+              <ResourceDetails
+                resource={customer}
+                onUpdated={async () => {
+                  void mutateCustomer()
+                }}
+              />
             </Spacer>
             {!isMockedId(customer.id) && (
               <>

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -26,9 +26,9 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
+    "@commercelayer/app-elements": "^2.10.0",
     "@commercelayer/eslint-config-ts-react": "^1.4.5",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/sdk": "6.23.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@vitejs/plugin-react": "^4.3.2",
@@ -45,7 +45,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@types/testing-library__jest-dom": "^6.0.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",

--- a/apps/exports/src/pages/DetailsPage.tsx
+++ b/apps/exports/src/pages/DetailsPage.tsx
@@ -57,7 +57,7 @@ const DetailsPage = (): JSX.Element | null => {
 
   return (
     <ExportDetailsProvider exportId={exportId}>
-      {({ state: { isLoading, data, isNotFound } }) =>
+      {({ state: { isLoading, data, isNotFound }, refetch }) =>
         isNotFound ? (
           <ErrorNotFound />
         ) : (
@@ -93,7 +93,12 @@ const DetailsPage = (): JSX.Element | null => {
               </Spacer>
 
               <Spacer top='14'>
-                <ResourceDetails resource={data} />
+                <ResourceDetails
+                  resource={data}
+                  onUpdated={async () => {
+                    void refetch()
+                  }}
+                />
               </Spacer>
               {!isMockedId(data.id) && (
                 <Spacer top='14'>

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -33,7 +33,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/gift_cards/src/pages/GiftCardDetails.tsx
+++ b/apps/gift_cards/src/pages/GiftCardDetails.tsx
@@ -180,7 +180,12 @@ const GiftCardDetails: FC<PageProps<typeof appRoutes.details>> = ({
           <BalanceLog giftCard={giftCard} />
         </Spacer>
         <Spacer top='14'>
-          <ResourceDetails resource={giftCard} />
+          <ResourceDetails
+            resource={giftCard}
+            onUpdated={async () => {
+              void mutateGiftCard()
+            }}
+          />
         </Spacer>
         {!isMockedId(giftCard.id) && (
           <>

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -26,9 +26,9 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
+    "@commercelayer/app-elements": "^2.10.0",
     "@commercelayer/eslint-config-ts-react": "^1.4.5",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/sdk": "6.23.0",
     "@vitejs/plugin-react": "^4.3.2",
     "lodash": "^4.17.21",
     "papaparse": "^5.4.1",
@@ -47,7 +47,7 @@
     "@types/node": "22.7.5",
     "@types/papaparse": "^5.3.14",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@types/testing-library__jest-dom": "^6.0.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",

--- a/apps/imports/src/pages/DetailsPage.tsx
+++ b/apps/imports/src/pages/DetailsPage.tsx
@@ -56,7 +56,7 @@ const DetailsPage = (): JSX.Element | null => {
 
   return (
     <ImportDetailsProvider importId={importId}>
-      {({ state: { data, isLoading, isNotFound } }) =>
+      {({ state: { data, isLoading, isNotFound }, refetch }) =>
         isNotFound ? (
           <ErrorNotFound />
         ) : (
@@ -88,7 +88,12 @@ const DetailsPage = (): JSX.Element | null => {
               </Spacer>
 
               <Spacer bottom='14'>
-                <ResourceDetails resource={data} />
+                <ResourceDetails
+                  resource={data}
+                  onUpdated={async () => {
+                    void refetch()
+                  }}
+                />
               </Spacer>
 
               {!isMockedId(data.id) && (

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -34,7 +34,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/inventory/src/pages/StockItemDetails.tsx
+++ b/apps/inventory/src/pages/StockItemDetails.tsx
@@ -34,7 +34,8 @@ export const StockItemDetails: FC = () => {
   const stockLocationId = params?.stockLocationId ?? ''
   const stockItemId = params?.stockItemId ?? ''
 
-  const { stockItem, isLoading, error } = useStockItemDetails(stockItemId)
+  const { stockItem, isLoading, error, mutateStockItem } =
+    useStockItemDetails(stockItemId)
 
   const { sdkClient } = useCoreSdkProvider()
 
@@ -135,7 +136,12 @@ export const StockItemDetails: FC = () => {
             <StockItemInfo stockItem={stockItem} />
           </Spacer>
           <Spacer top='14'>
-            <ResourceDetails resource={stockItem} />
+            <ResourceDetails
+              resource={stockItem}
+              onUpdated={async () => {
+                void mutateStockItem()
+              }}
+            />
           </Spacer>
           <Spacer top='14'>
             <ResourceMetadata

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "^6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "^6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "dashboard-apps-common": "workspace:*",
     "date-fns": "^4.1.0",
@@ -35,7 +35,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/orders/src/pages/OrderDetails.tsx
+++ b/apps/orders/src/pages/OrderDetails.tsx
@@ -39,7 +39,7 @@ function OrderDetails(): JSX.Element {
 
   const orderId = params?.orderId ?? ''
 
-  const { order, isLoading, error } = useOrderDetails(orderId)
+  const { order, isLoading, error, mutateOrder } = useOrderDetails(orderId)
   const { returns, isLoadingReturns } = useOrderReturns(orderId)
   const toolbar = useOrderToolbar({ order })
 
@@ -174,7 +174,12 @@ function OrderDetails(): JSX.Element {
             </Spacer>
           )}
           <Spacer top='14'>
-            <ResourceDetails resource={order} />
+            <ResourceDetails
+              resource={order}
+              onUpdated={async () => {
+                void mutateOrder()
+              }}
+            />
           </Spacer>
           {!isMockedId(order.id) && (
             <>

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -34,7 +34,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/price_lists/src/pages/PriceDetails.tsx
+++ b/apps/price_lists/src/pages/PriceDetails.tsx
@@ -143,7 +143,12 @@ export function PriceDetails(): JSX.Element {
             />
           </Spacer>
           <Spacer top='14'>
-            <ResourceDetails resource={price} />
+            <ResourceDetails
+              resource={price}
+              onUpdated={async () => {
+                void mutatePrice()
+              }}
+            />
           </Spacer>
           <Spacer top='14'>
             <ResourceMetadata

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "p-memoize": "^7.1.1",
@@ -35,7 +35,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/promotions/src/pages/PromotionDetailsPage.tsx
+++ b/apps/promotions/src/pages/PromotionDetailsPage.tsx
@@ -165,7 +165,12 @@ function Page(
         </Spacer>
 
         <Spacer top='14'>
-          <ResourceDetails resource={promotion} />
+          <ResourceDetails
+            resource={promotion}
+            onUpdated={async () => {
+              void mutatePromotion()
+            }}
+          />
         </Spacer>
 
         {!isMockedId(promotion.id) && (

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -33,7 +33,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/returns/src/pages/ReturnDetails.tsx
+++ b/apps/returns/src/pages/ReturnDetails.tsx
@@ -34,7 +34,7 @@ export function ReturnDetails(): JSX.Element {
 
   const returnId = params?.returnId ?? ''
 
-  const { returnObj, isLoading } = useReturnDetails(returnId)
+  const { returnObj, isLoading, mutateReturn } = useReturnDetails(returnId)
 
   if (returnId === undefined || !canUser('read', 'returns')) {
     return (
@@ -118,7 +118,12 @@ export function ReturnDetails(): JSX.Element {
             <ReturnAddresses returnObj={returnObj} />
           </Spacer>
           <Spacer top='14'>
-            <ResourceDetails resource={returnObj} />
+            <ResourceDetails
+              resource={returnObj}
+              onUpdated={async () => {
+                void mutateReturn()
+              }}
+            />
           </Spacer>
           {!isMockedId(returnObj.id) && (
             <>

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -34,7 +34,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/shipments/src/pages/ShipmentDetails.tsx
+++ b/apps/shipments/src/pages/ShipmentDetails.tsx
@@ -35,7 +35,7 @@ export function ShipmentDetails(): JSX.Element {
 
   const shipmentId = params?.shipmentId ?? ''
 
-  const { shipment, isLoading } = useShipmentDetails(shipmentId)
+  const { shipment, isLoading, mutateShipment } = useShipmentDetails(shipmentId)
   const pageToolbar = useShipmentToolbar({ shipment })
 
   if (shipmentId === undefined || !canUser('read', 'orders')) {
@@ -126,7 +126,12 @@ export function ShipmentDetails(): JSX.Element {
             <ShipmentAddresses shipment={shipment} />
           </Spacer>
           <Spacer top='14'>
-            <ResourceDetails resource={shipment} />
+            <ResourceDetails
+              resource={shipment}
+              onUpdated={async () => {
+                void mutateShipment()
+              }}
+            />
           </Spacer>
           {!isMockedId(shipment.id) && (
             <>

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "dashboard-apps-common": "workspace:*",
     "lodash": "^4.17.21",
@@ -35,7 +35,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/sku_lists/src/pages/SkuListDetails.tsx
+++ b/apps/sku_lists/src/pages/SkuListDetails.tsx
@@ -38,7 +38,8 @@ export const SkuListDetails = (
   const [, setLocation] = useLocation()
   const skuListId = props.params?.skuListId ?? ''
 
-  const { skuList, isLoading, error } = useSkuListDetails(skuListId)
+  const { skuList, isLoading, error, mutateSkuList } =
+    useSkuListDetails(skuListId)
 
   const { Overlay: DeleteOverlay, show: showDeleteOverlay } =
     useSkuListDeleteOverlay(skuList)
@@ -203,7 +204,12 @@ export const SkuListDetails = (
           ) : null}
           <Tab name='Info'>
             <Spacer top='10'>
-              <ResourceDetails resource={skuList} />
+              <ResourceDetails
+                resource={skuList}
+                onUpdated={async () => {
+                  void mutateSkuList()
+                }}
+              />
             </Spacer>
             {!isMockedId(skuList.id) && (
               <Spacer top='14'>

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "dashboard-apps-common": "workspace:*",
     "lodash": "^4.17.21",
@@ -36,7 +36,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/skus/src/pages/SkuDetails.tsx
+++ b/apps/skus/src/pages/SkuDetails.tsx
@@ -40,7 +40,7 @@ export const SkuDetails: FC = () => {
 
   const skuId = params?.skuId ?? ''
 
-  const { sku, isLoading, error } = useSkuDetails(skuId)
+  const { sku, isLoading, error, mutateSku } = useSkuDetails(skuId)
 
   const { Overlay: SkuDeleteOverlay, show } = useSkuDeleteOverlay(sku)
 
@@ -119,7 +119,12 @@ export const SkuDetails: FC = () => {
         <SkuInfo sku={sku} />
       </Spacer>
       <Spacer top='14'>
-        <ResourceDetails resource={sku} />
+        <ResourceDetails
+          resource={sku}
+          onUpdated={async () => {
+            void mutateSku()
+          }}
+        />
       </Spacer>
       {!isMockedId(sku.id) && (
         <>

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -33,7 +33,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/stock_transfers/src/pages/StockTransferDetails.tsx
+++ b/apps/stock_transfers/src/pages/StockTransferDetails.tsx
@@ -42,7 +42,8 @@ export function StockTransferDetails(): JSX.Element {
 
   const stockTransferId = params?.stockTransferId ?? ''
 
-  const { stockTransfer, isLoading } = useStockTransferDetails(stockTransferId)
+  const { stockTransfer, isLoading, mutateStockTransfer } =
+    useStockTransferDetails(stockTransferId)
 
   if (stockTransferId === '' || !canUser('read', 'stock_transfers')) {
     return (
@@ -178,7 +179,12 @@ export function StockTransferDetails(): JSX.Element {
             <StockTransferAddresses stockTransfer={stockTransfer} />
           </Spacer>
           <Spacer top='14'>
-            <ResourceDetails resource={stockTransfer} />
+            <ResourceDetails
+              resource={stockTransfer}
+              onUpdated={async () => {
+                void mutateStockTransfer()
+              }}
+            />
           </Spacer>
           {!isMockedId(stockTransfer.id) && (
             <Spacer top='14'>

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -15,8 +15,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "^2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
@@ -33,7 +33,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -26,8 +26,8 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "lodash": "^4.17.21",
     "phosphor-react": "^1.4.1",
@@ -45,7 +45,7 @@
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",

--- a/apps/webhooks/src/pages/WebhookDetails.tsx
+++ b/apps/webhooks/src/pages/WebhookDetails.tsx
@@ -24,7 +24,7 @@ export const WebhookDetails: FC = () => {
   const [, setLocation] = useLocation()
 
   const webhookId = params?.webhookId ?? ''
-  const { webhook, isLoading } = useWebhookDetails(webhookId)
+  const { webhook, isLoading, mutateWebhook } = useWebhookDetails(webhookId)
 
   if (webhookId == null || !canUser('read', 'webhooks')) {
     return (
@@ -103,7 +103,12 @@ export const WebhookDetails: FC = () => {
         </Spacer>
         <WebhookCallback webhook={webhook} />
         <Spacer top='14'>
-          <ResourceDetails resource={webhook} />
+          <ResourceDetails
+            resource={webhook}
+            onUpdated={async () => {
+              void mutateWebhook()
+            }}
+          />
         </Spacer>
         <Spacer top='14'>
           <ResourceMetadata

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,8 +9,8 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "2.9.0",
-    "@commercelayer/sdk": "^6.22.0",
+    "@commercelayer/app-elements": "2.10.0",
+    "@commercelayer/sdk": "^6.23.0",
     "@hookform/resolvers": "^3.9.0",
     "date-fns": "^4.1.0",
     "react": "^18.3.1",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^2.9.0",
+    "@commercelayer/app-elements": "^2.10.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -22,12 +22,12 @@
   "devDependencies": {
     "@commercelayer/app-builder": "workspace:*",
     "@commercelayer/eslint-config-ts-react": "^1.4.5",
-    "@commercelayer/js-auth": "^6.6.0",
+    "@commercelayer/js-auth": "^6.6.1",
     "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.17.10",
     "@types/node": "22.7.5",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.0",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^8.57.0",
     "js-cookie": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -65,7 +65,7 @@ importers:
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -76,8 +76,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -106,11 +106,11 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -155,8 +155,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -185,20 +185,20 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.4.5
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@testing-library/jest-dom':
         specifier: ^6.5.0
         version: 6.5.0
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -237,8 +237,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@types/testing-library__jest-dom':
         specifier: ^6.0.0
         version: 6.0.0
@@ -273,11 +273,11 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -322,8 +322,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -352,14 +352,14 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.4.5
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -393,7 +393,7 @@ importers:
         version: 6.5.0
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -410,8 +410,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@types/testing-library__jest-dom':
         specifier: ^6.0.0
         version: 6.0.0
@@ -446,11 +446,11 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -487,7 +487,7 @@ importers:
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -498,8 +498,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -528,11 +528,11 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: ^6.22.0
-        version: 6.22.0
+        specifier: ^6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -583,8 +583,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -613,11 +613,11 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -654,7 +654,7 @@ importers:
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -665,8 +665,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -695,11 +695,11 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -739,7 +739,7 @@ importers:
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -750,8 +750,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -780,11 +780,11 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -829,8 +829,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -859,11 +859,11 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -900,7 +900,7 @@ importers:
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -911,8 +911,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -941,11 +941,11 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -996,8 +996,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -1026,11 +1026,11 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -1073,7 +1073,7 @@ importers:
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@testing-library/react':
         specifier: ^16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -1084,8 +1084,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -1114,11 +1114,11 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -1163,8 +1163,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -1193,11 +1193,11 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -1242,8 +1242,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -1272,11 +1272,11 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: 6.22.0
-        version: 6.22.0
+        specifier: 6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -1324,8 +1324,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -1375,11 +1375,11 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: 2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       '@commercelayer/sdk':
-        specifier: ^6.22.0
-        version: 6.22.0
+        specifier: ^6.23.0
+        version: 6.23.0
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.9.0(react-hook-form@7.53.0(react@18.3.1))
@@ -1421,8 +1421,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^2.9.0
-        version: 2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
+        specifier: ^2.10.0
+        version: 2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1443,8 +1443,8 @@ importers:
         specifier: ^1.4.5
         version: 1.4.5(eslint@8.57.0)(react@18.3.1)(typescript@5.6.3)
       '@commercelayer/js-auth':
-        specifier: ^6.6.0
-        version: 6.6.0
+        specifier: ^6.6.1
+        version: 6.6.1
       '@types/js-cookie':
         specifier: ^3.0.6
         version: 3.0.6
@@ -1458,8 +1458,8 @@ importers:
         specifier: ^18.3.11
         version: 18.3.11
       '@types/react-dom':
-        specifier: ^18.3.0
-        version: 18.3.0
+        specifier: ^18.3.1
+        version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5))
@@ -1588,8 +1588,8 @@ packages:
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
 
-  '@commercelayer/app-elements@2.9.0':
-    resolution: {integrity: sha512-TQn3i98qF2XNyU2h4GlLlnOo7W2hj95tPM7sdYeu8zrjKx9j4AeOueaedj3gAvC8u6MrmBIBqsP32uVc9YR22Q==}
+  '@commercelayer/app-elements@2.10.0':
+    resolution: {integrity: sha512-CBycNBlXa77F//4QP3z7WHQOzDZgB5zdj7gHEfenFuUaGI0WKiuC9PXF8RTP8+526N6eS4UbejqfTrN3z7R68w==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -1613,12 +1613,12 @@ packages:
       eslint: '>=8.0'
       typescript: '>=5.0'
 
-  '@commercelayer/js-auth@6.6.0':
-    resolution: {integrity: sha512-daPrI5Vdc2SyvyvtyJgPagSQntJ4+QhPBrZrftN161A4y3nhUaHBxwRYSU8CM9I/+Qzd/xlQoWi+bpxMBdHwMA==}
+  '@commercelayer/js-auth@6.6.1':
+    resolution: {integrity: sha512-r0Aa7poj8Dfd0JPJwLR/MaZchAhTVW8/6Qx2yDC36CcP/G5Am/DCNZiLoDcnbxObjCB6JJvEbkDnFamHcM/c3Q==}
     engines: {node: '>=18.0.0'}
 
-  '@commercelayer/sdk@6.22.0':
-    resolution: {integrity: sha512-iaNFlW5QXE/+/4fsAwhGZ1j3H3PVcablNuRnOCXyMZ2keybJsQ/VEfJDeUnpD3FLEjDyUa4Z+HJzlgb+373puw==}
+  '@commercelayer/sdk@6.23.0':
+    resolution: {integrity: sha512-S2rMXVd+daY4DjAMvKKhp6U0Hu+C+Yb1wN3V/I8Z9Sl27fziMI0621LSeVBGQNh9tFMCa46spV2PCHFr4dSsHw==}
     engines: {node: '>=20'}
 
   '@emnapi/core@1.2.0':
@@ -2324,8 +2324,8 @@ packages:
     resolution: {integrity: sha512-4tWwOUq589tozyQPBVEqGNng5DaZkomx5IVNuur868yYdgjH6RaL373/HKiVt1IDoNNXYiTGspm1F7kjrarM8Q==}
     deprecated: This is a stub types definition. react-datepicker provides its own type definitions, so you do not need this installed.
 
-  '@types/react-dom@18.3.0':
-    resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
+  '@types/react-dom@18.3.1':
+    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
   '@types/react-transition-group@4.4.11':
     resolution: {integrity: sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==}
@@ -5848,13 +5848,13 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
-  '@commercelayer/app-elements@2.9.0(@commercelayer/sdk@6.22.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))':
+  '@commercelayer/app-elements@2.10.0(@commercelayer/sdk@6.23.0)(query-string@9.1.1)(react-dom@18.3.1(react@18.3.1))(react-gtm-module@2.0.11)(react-hook-form@7.53.0(react@18.3.1))(react@18.3.1)(wouter@3.3.5(react@18.3.1))':
     dependencies:
-      '@commercelayer/sdk': 6.22.0
+      '@commercelayer/sdk': 6.23.0
       '@types/lodash': 4.17.10
       '@types/react': 18.3.11
       '@types/react-datepicker': 7.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/react-dom': 18.3.0
+      '@types/react-dom': 18.3.1
       classnames: 2.5.1
       jwt-decode: 4.0.0
       lodash: 4.17.21
@@ -5911,9 +5911,9 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@commercelayer/js-auth@6.6.0': {}
+  '@commercelayer/js-auth@6.6.1': {}
 
-  '@commercelayer/sdk@6.22.0': {}
+  '@commercelayer/sdk@6.23.0': {}
 
   '@emnapi/core@1.2.0':
     dependencies:
@@ -6649,7 +6649,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
       '@testing-library/dom': 10.4.0
@@ -6657,7 +6657,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.11
-      '@types/react-dom': 18.3.0
+      '@types/react-dom': 18.3.1
 
   '@tufjs/canonical-json@2.0.0': {}
 
@@ -6730,7 +6730,7 @@ snapshots:
       - react
       - react-dom
 
-  '@types/react-dom@18.3.0':
+  '@types/react-dom@18.3.1':
     dependencies:
       '@types/react': 18.3.11
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Updated all deps to latest major.
- Updated all implementations of `ResourceDetails` component tu support the new `Reference / Reference origin update feature` that now requires to fill a brand new `onUpdated` prop. 

All apps were tested locally to check the new `Reference / Reference origin update feature` without any issue.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
