### PR TITLE
Fix edit form default values in `skus` app

### DIFF
--- a/apps/skus/src/pages/SkuEdit.tsx
+++ b/apps/skus/src/pages/SkuEdit.tsx
@@ -106,7 +106,7 @@ function adaptSkuToFormValues(sku?: Sku): SkuFormValues {
     code: sku?.code ?? '',
     name: sku?.name ?? '',
     description: sku?.description ?? '',
-    shippingCategory: sku?.shipping_category?.id ?? '',
+    shippingCategory: sku?.shipping_category?.id ?? null,
     weight: sku?.weight?.toString() ?? '',
     unitOfWeight: sku?.unit_of_weight ?? '',
     piecesPerPack: sku?.pieces_per_pack?.toString() ?? '',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed default values in edit page of `skus` app to have the correct empty value of the `shipping_category` relationship.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
