### PR TITLE
Add `All inventory` page in `inventory` app

### DIFF
--- a/apps/inventory/src/App.tsx
+++ b/apps/inventory/src/App.tsx
@@ -19,6 +19,9 @@ export const App: FC<AppProps> = ({ routerBase }) => {
         <Route path={appRoutes.home.path}>
           <Home />
         </Route>
+        <Route path={appRoutes.list.path}>
+          <StockItemsList />
+        </Route>
         <Route path={appRoutes.stockLocation.path}>
           <StockItemsList />
         </Route>

--- a/apps/inventory/src/components/ListItemSku.tsx
+++ b/apps/inventory/src/components/ListItemSku.tsx
@@ -45,12 +45,7 @@ export const ListItemSku = withSkeletonTemplate<Props>(
           </Text>
         </div>
         {variant === 'boxed' && !disabled && (
-          <Icon
-            name='pencilSimple'
-            size='18'
-            weight='bold'
-            className='text-primary'
-          />
+          <Icon name='pencilSimple' size='16' weight='bold' />
         )}
       </ListItem>
     )

--- a/apps/inventory/src/components/ListItemStockItem.tsx
+++ b/apps/inventory/src/components/ListItemStockItem.tsx
@@ -27,6 +27,9 @@ export const ListItemStockItem = withSkeletonTemplate<Props>(
 
     const stockLocationId = params?.stockLocationId ?? ''
 
+    const hasReservedStock =
+      resource.reserved_stock != null && resource.reserved_stock.quantity > 0
+
     return (
       <ListItem
         icon={
@@ -57,20 +60,19 @@ export const ListItemStockItem = withSkeletonTemplate<Props>(
             </Text>
           </div>
           {stockLocationId === '' && (
-            <Spacer bottom='2'>
+            <Spacer bottom={hasReservedStock ? '2' : undefined}>
               <Text tag='div' weight='medium' variant='info' size='small'>
                 {resource.stock_location?.name}
               </Text>
             </Spacer>
           )}
-          {resource.reserved_stock != null &&
-            resource.reserved_stock.quantity > 0 && (
-              <Spacer top='1'>
-                <Badge variant='warning' icon='lockSimple'>
-                  {resource.reserved_stock?.quantity} reserved
-                </Badge>
-              </Spacer>
-            )}
+          {hasReservedStock && (
+            <Spacer top='1'>
+              <Badge variant='warning' icon='lockSimple'>
+                {resource.reserved_stock?.quantity} reserved
+              </Badge>
+            </Spacer>
+          )}
         </div>
       </ListItem>
     )

--- a/apps/inventory/src/components/ListItemStockItem.tsx
+++ b/apps/inventory/src/components/ListItemStockItem.tsx
@@ -43,12 +43,24 @@ export const ListItemStockItem = withSkeletonTemplate<Props>(
         }}
       >
         <div>
-          <Text tag='div' weight='medium' variant='info' size='small'>
-            {resource.sku?.code}
-          </Text>
-          <Text tag='div' weight='semibold'>
-            {resource.sku?.name}
-          </Text>
+          <div className='flex justify-between items-end'>
+            <div>
+              <Text tag='div' weight='medium' variant='info' size='small'>
+                {resource.sku?.code}
+              </Text>
+              <Text tag='div' weight='semibold'>
+                {resource.sku?.name}
+              </Text>
+            </div>
+            <Text weight='semibold' wrap='nowrap'>
+              {resource.quantity}
+            </Text>
+          </div>
+          {stockLocationId === '' && (
+            <Text tag='div' weight='medium' variant='info' size='small'>
+              {resource.stock_location?.name}
+            </Text>
+          )}
           {resource.reserved_stock != null &&
             resource.reserved_stock.quantity > 0 && (
               <Spacer top='1'>
@@ -58,9 +70,6 @@ export const ListItemStockItem = withSkeletonTemplate<Props>(
               </Spacer>
             )}
         </div>
-        <Text weight='semibold' wrap='nowrap'>
-          x {resource.quantity}
-        </Text>
       </ListItem>
     )
   }

--- a/apps/inventory/src/components/ListItemStockItem.tsx
+++ b/apps/inventory/src/components/ListItemStockItem.tsx
@@ -57,9 +57,11 @@ export const ListItemStockItem = withSkeletonTemplate<Props>(
             </Text>
           </div>
           {stockLocationId === '' && (
-            <Text tag='div' weight='medium' variant='info' size='small'>
-              {resource.stock_location?.name}
-            </Text>
+            <Spacer bottom='2'>
+              <Text tag='div' weight='medium' variant='info' size='small'>
+                {resource.stock_location?.name}
+              </Text>
+            </Spacer>
           )}
           {resource.reserved_stock != null &&
             resource.reserved_stock.quantity > 0 && (

--- a/apps/inventory/src/components/ListItemStockLocation.tsx
+++ b/apps/inventory/src/components/ListItemStockLocation.tsx
@@ -26,7 +26,7 @@ export const ListItemStockLocation = withSkeletonTemplate<Props>(
         }}
       >
         <div>
-          <Text weight='bold'>{resource.name}</Text>
+          <Text weight='semibold'>{resource.name}</Text>
         </div>
         <Icon name='caretRight' />
       </ListItem>

--- a/apps/inventory/src/components/StockItemForm.tsx
+++ b/apps/inventory/src/components/StockItemForm.tsx
@@ -20,7 +20,7 @@ import { StockLocationSelector } from './StockLocationSelector'
 
 const stockItemFormSchema = z.object({
   id: z.string().optional(),
-  stockLocation: z.string().optional(),
+  stockLocation: z.string().min(1),
   item: z.string().min(1),
   quantity: z.string().min(0)
 })

--- a/apps/inventory/src/components/StockItemForm.tsx
+++ b/apps/inventory/src/components/StockItemForm.tsx
@@ -5,6 +5,7 @@ import {
   HookedInput,
   HookedValidationApiError,
   HookedValidationError,
+  InputSelect,
   Section,
   Spacer,
   Text
@@ -15,9 +16,11 @@ import { useState } from 'react'
 import { useForm, type UseFormSetError } from 'react-hook-form'
 import { z } from 'zod'
 import { ListItemSku } from './ListItemSku'
+import { StockLocationSelector } from './StockLocationSelector'
 
 const stockItemFormSchema = z.object({
   id: z.string().optional(),
+  stockLocation: z.string().optional(),
   item: z.string().min(1),
   quantity: z.string().min(0)
 })
@@ -63,20 +66,29 @@ export function StockItemForm({
         }}
       >
         <Section>
-          <Spacer top='12' bottom='4'>
+          {defaultValues?.stockLocation == null && (
+            <Spacer top='12' bottom='4'>
+              <StockLocationSelector />
+            </Spacer>
+          )}
+          <Spacer
+            top={defaultValues?.stockLocation == null ? '6' : '12'}
+            bottom='4'
+          >
             <Text weight='semibold'>SKU</Text>
             <Spacer top='2'>
               {stockItemFormWatchedItem == null ? (
-                <Button
-                  type='button'
-                  variant='relationship'
-                  fullWidth
+                <div
                   onClick={() => {
                     showAddItemOverlay({ type: 'skus' })
                   }}
                 >
-                  Add item
-                </Button>
+                  <InputSelect
+                    initialValues={[]}
+                    placeholder='Select an SKU'
+                    onSelect={() => {}}
+                  />
+                </div>
               ) : (
                 <ListItemSku
                   resource={sku}

--- a/apps/inventory/src/components/StockItemForm.tsx
+++ b/apps/inventory/src/components/StockItemForm.tsx
@@ -3,9 +3,8 @@ import {
   Button,
   HookedForm,
   HookedInput,
+  HookedInputSelect,
   HookedValidationApiError,
-  HookedValidationError,
-  InputSelect,
   Section,
   Spacer,
   Text
@@ -83,7 +82,8 @@ export function StockItemForm({
                     showAddItemOverlay({ type: 'skus' })
                   }}
                 >
-                  <InputSelect
+                  <HookedInputSelect
+                    name='item'
                     initialValues={[]}
                     placeholder='Select an SKU'
                     onSelect={() => {}}
@@ -101,9 +101,6 @@ export function StockItemForm({
                   }}
                 />
               )}
-              <Spacer top='2'>
-                <HookedValidationError name='item' />
-              </Spacer>
               <AddItemOverlay
                 onConfirm={(resource) => {
                   setSelectedItemResource(resource)

--- a/apps/inventory/src/components/StockItemInfo.tsx
+++ b/apps/inventory/src/components/StockItemInfo.tsx
@@ -10,7 +10,7 @@ interface Props {
 export const StockItemInfo: FC<Props> = ({ stockItem = makeStockItem() }) => {
   return (
     <Section title='Info'>
-      <ListDetailsItem label='Stock Location' gutter='none'>
+      <ListDetailsItem label='Stock location' gutter='none'>
         <Text tag='div' weight='semibold'>
           {stockItem.stock_location?.name}
         </Text>

--- a/apps/inventory/src/components/StockLocationSelector.tsx
+++ b/apps/inventory/src/components/StockLocationSelector.tsx
@@ -1,0 +1,113 @@
+import {
+  HookedInputSelect,
+  useCoreApi,
+  useCoreSdkProvider,
+  type InputSelectValue
+} from '@commercelayer/app-elements'
+import type { ListResponse, Resource, StockLocation } from '@commercelayer/sdk'
+import isEmpty from 'lodash/isEmpty'
+import isString from 'lodash/isString'
+import { type FC } from 'react'
+import { useFormContext } from 'react-hook-form'
+
+export const StockLocationSelector: FC = () => {
+  const { sdkClient } = useCoreSdkProvider()
+  const { setValue } = useFormContext()
+  const { data, isLoading: isLoadingInitialValues } = useCoreApi(
+    'stock_locations',
+    'list',
+    [
+      {
+        fields: {
+          stock_locations: ['name']
+        },
+        pageSize: 25,
+        sort: {
+          name: 'asc'
+        }
+      }
+    ]
+  )
+
+  const hasMorePages =
+    (data?.meta?.pageCount != null && data.meta.pageCount > 1) ?? false
+
+  const initialValues = [
+    ...makeSelectInitialValuesWithDefault<StockLocation>({
+      resourceList: data,
+      fieldForLabel: 'name'
+    })
+  ]
+
+  return (
+    <HookedInputSelect
+      name='stockLocation'
+      label='Stock location'
+      placeholder='Select a stock location'
+      initialValues={initialValues}
+      isLoading={isLoadingInitialValues}
+      isClearable={false}
+      isSearchable
+      onSelect={(selected) => {
+        if (isString(selected) && !isEmpty(selected)) {
+          setValue('stockLocation', selected)
+        }
+      }}
+      menuFooterText={
+        hasMorePages
+          ? 'Showing 25 results. Type to search for more options.'
+          : undefined
+      }
+      loadAsyncValues={
+        hasMorePages
+          ? async (hint) => {
+              return await sdkClient.stock_locations
+                .list({
+                  pageSize: 25,
+                  filters: {
+                    name_cont: hint,
+                    fields: {
+                      stock_locations: ['name']
+                    }
+                  }
+                })
+                .then((res) => {
+                  return res.map((stockLocation) => ({
+                    label: stockLocation.name,
+                    value: stockLocation.id
+                  }))
+                })
+            }
+          : undefined
+      }
+    />
+  )
+}
+
+function makeSelectInitialValuesWithDefault<R extends Resource>({
+  resourceList,
+  defaultResource,
+  fieldForLabel
+}: {
+  resourceList?: ListResponse<R>
+  defaultResource?: R
+  fieldForLabel: keyof R
+}): InputSelectValue[] {
+  const options = [
+    defaultResource != null
+      ? {
+          label: (
+            defaultResource[fieldForLabel] ?? defaultResource.id
+          ).toString(),
+          value: defaultResource.id
+        }
+      : undefined,
+    ...(resourceList ?? []).map((item) => ({
+      label: (item[fieldForLabel] ?? item.id).toString(),
+      value: item.id,
+      meta: item
+    }))
+  ].filter((v) => !isEmpty(v)) as InputSelectValue[]
+
+  return options.sort((a, b) => a.label.localeCompare(b.label))
+}

--- a/apps/inventory/src/data/filters.ts
+++ b/apps/inventory/src/data/filters.ts
@@ -1,41 +1,30 @@
 import type { FiltersInstructions } from '@commercelayer/app-elements'
 
-export const stockLocationsInstructions: FiltersInstructions = [
-  {
-    label: 'Search',
-    type: 'textSearch',
-    sdk: {
-      predicate: ['name'].join('_or_') + '_cont'
-    },
-    render: {
-      component: 'searchBar'
-    }
-  }
-]
-
 interface StockItemsInstructionsConfig {
-  stockLocationId: string
+  stockLocationId?: string
 }
 
 export const stockItemsInstructions = ({
   stockLocationId
-}: StockItemsInstructionsConfig): FiltersInstructions => [
-  {
-    label: 'Stock location',
-    type: 'options',
-    sdk: {
-      predicate: 'stock_location_id_in',
-      defaultOptions: [stockLocationId]
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'single',
-        options: [{ value: stockLocationId, label: stockLocationId }]
+}: StockItemsInstructionsConfig): FiltersInstructions => {
+  const instructions: FiltersInstructions = []
+  if (stockLocationId != null)
+    instructions.push({
+      label: 'Stock location',
+      type: 'options',
+      sdk: {
+        predicate: 'stock_location_id_in',
+        defaultOptions: [stockLocationId]
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'single',
+          options: [{ value: stockLocationId, label: stockLocationId }]
+        }
       }
-    }
-  },
-  {
+    })
+  instructions.push({
     label: 'Search',
     type: 'textSearch',
     sdk: {
@@ -44,5 +33,6 @@ export const stockItemsInstructions = ({
     render: {
       component: 'searchBar'
     }
-  }
-]
+  })
+  return instructions
+}

--- a/apps/inventory/src/data/routes.ts
+++ b/apps/inventory/src/data/routes.ts
@@ -9,22 +9,27 @@ export const appRoutes = {
     path: '/',
     makePath: () => '/'
   },
+  list: {
+    path: '/list',
+    makePath: () => '/list'
+  },
   stockLocation: {
     path: '/:stockLocationId/list',
     makePath: (stockLocationId: string) => `/${stockLocationId}/list`
   },
   stockItem: {
-    path: '/:stockLocationId/list/:stockItemId',
+    path: '/:stockLocationId?/list/:stockItemId',
     makePath: (stockLocationId: string, stockItemId: string) =>
-      `/${stockLocationId}/list/${stockItemId}`
+      `/${stockLocationId !== '' ? `${stockLocationId}/` : ''}list/${stockItemId}`
   },
   newStockItem: {
-    path: '/:stockLocationId/new',
-    makePath: (stockLocationId: string) => `/${stockLocationId}/new`
+    path: '/:stockLocationId?/new',
+    makePath: (stockLocationId: string) =>
+      `/${stockLocationId !== '' ? `${stockLocationId}/` : ''}new`
   },
   editStockItem: {
-    path: '/:stockLocationId/list/:stockItemId/edit',
+    path: '/:stockLocationId?/list/:stockItemId/edit',
     makePath: (stockLocationId: string, stockItemId: string) =>
-      `/${stockLocationId}/list/${stockItemId}/edit`
+      `/${stockLocationId !== '' ? `${stockLocationId}/` : ''}list/${stockItemId}/edit`
   }
 }

--- a/apps/inventory/src/hooks/useStockLocationDetails.tsx
+++ b/apps/inventory/src/hooks/useStockLocationDetails.tsx
@@ -14,9 +14,14 @@ export function useStockLocationDetails(id: string): {
     isLoading,
     error,
     mutate: mutateStockLocation
-  } = useCoreApi('stock_locations', 'retrieve', !isMockedId(id) ? [id] : null, {
-    fallbackData: makeStockLocation()
-  })
+  } = useCoreApi(
+    'stock_locations',
+    'retrieve',
+    id !== '' && !isMockedId(id) ? [id] : null,
+    {
+      fallbackData: makeStockLocation()
+    }
+  )
 
   return { stockLocation, error, isLoading, mutateStockLocation }
 }

--- a/apps/inventory/src/pages/StockItemDetails.tsx
+++ b/apps/inventory/src/pages/StockItemDetails.tsx
@@ -42,13 +42,18 @@ export const StockItemDetails: FC = () => {
 
   const [isDeleting, setIsDeleting] = useState(false)
 
+  const backLink =
+    stockLocationId !== ''
+      ? appRoutes.stockLocation.makePath(stockLocationId)
+      : appRoutes.list.makePath()
+
   if (error != null) {
     return (
       <PageLayout
         title='Stock items'
         navigationButton={{
           onClick: () => {
-            setLocation(appRoutes.stockLocation.makePath(stockLocationId))
+            setLocation(backLink)
           },
           label: 'Stock location',
           icon: 'arrowLeft'
@@ -58,7 +63,7 @@ export const StockItemDetails: FC = () => {
         <EmptyState
           title='Not authorized'
           action={
-            <Link href={appRoutes.stockLocation.makePath(stockLocationId)}>
+            <Link href={backLink}>
               <Button variant='primary'>Go back</Button>
             </Link>
           }
@@ -113,11 +118,10 @@ export const StockItemDetails: FC = () => {
         onClick: () => {
           goBack({
             setLocation,
-            defaultRelativePath:
-              appRoutes.stockLocation.makePath(stockLocationId)
+            defaultRelativePath: backLink
           })
         },
-        label: 'Stock location',
+        label: stockLocationId !== '' ? 'Stock location' : 'All inventory',
         icon: 'arrowLeft'
       }}
       toolbar={pageToolbar}
@@ -172,9 +176,7 @@ export const StockItemDetails: FC = () => {
                 void sdkClient.stock_items
                   .delete(stockItem.id)
                   .then(() => {
-                    setLocation(
-                      appRoutes.stockLocation.makePath(stockLocationId)
-                    )
+                    setLocation(backLink)
                   })
                   .catch(() => {})
               }}

--- a/apps/inventory/src/pages/StockItemEdit.tsx
+++ b/apps/inventory/src/pages/StockItemEdit.tsx
@@ -87,16 +87,14 @@ export function StockItemEdit(): JSX.Element {
             defaultValues={{
               id: stockItem.id,
               quantity: stockItem.quantity.toString(),
-              item: stockItem.sku?.id
+              item: stockItem.sku?.id,
+              stockLocation: stockItem.stock_location?.id
             }}
             apiError={apiError}
             isSubmitting={isSaving}
             onSubmit={(formValues) => {
               setIsSaving(true)
-              const stockItem = adaptFormValuesToStockItem(
-                formValues,
-                stockLocationId
-              )
+              const stockItem = adaptFormValuesToStockItem(formValues)
               void sdkClient.stock_items
                 .update(stockItem)
                 .then((updatedStockItem) => {
@@ -116,8 +114,7 @@ export function StockItemEdit(): JSX.Element {
 }
 
 function adaptFormValuesToStockItem(
-  formValues: StockItemFormValues,
-  stockLocationId: string
+  formValues: StockItemFormValues
 ): StockItemUpdate {
   return {
     id: formValues.id ?? '',
@@ -125,10 +122,6 @@ function adaptFormValuesToStockItem(
       id: formValues.item ?? null,
       type: 'skus'
     },
-    quantity: parseInt(formValues.quantity),
-    stock_location: {
-      id: stockLocationId,
-      type: 'stock_locations'
-    }
+    quantity: parseInt(formValues.quantity)
   }
 }

--- a/apps/inventory/src/pages/StockItemNew.tsx
+++ b/apps/inventory/src/pages/StockItemNew.tsx
@@ -29,7 +29,10 @@ export function StockItemNew(): JSX.Element {
 
   const stockLocationId = params?.stockLocationId ?? ''
 
-  const goBackUrl = appRoutes.stockLocation.makePath(stockLocationId)
+  const goBackUrl =
+    stockLocationId !== ''
+      ? appRoutes.stockLocation.makePath(stockLocationId)
+      : appRoutes.list.makePath()
 
   if (!canUser('create', 'stock_items')) {
     return (
@@ -75,6 +78,9 @@ export function StockItemNew(): JSX.Element {
       <Spacer bottom='14'>
         <StockItemForm
           defaultValues={{
+            ...(stockLocationId !== ''
+              ? { stockLocation: stockLocationId }
+              : {}),
             quantity: '1'
           }}
           apiError={apiError}
@@ -112,7 +118,10 @@ function adaptFormValuesToStockItem(
     },
     quantity: parseInt(formValues.quantity),
     stock_location: {
-      id: stockLocationId,
+      id:
+        stockLocationId !== ''
+          ? stockLocationId
+          : (formValues.stockLocation ?? ''),
       type: 'stock_locations'
     }
   }

--- a/apps/inventory/src/pages/StockItemsList.tsx
+++ b/apps/inventory/src/pages/StockItemsList.tsx
@@ -22,14 +22,14 @@ export function StockItemsList(): JSX.Element {
     settings: { mode }
   } = useTokenProvider()
 
-  const [, params] = useRoute<{ stockLocationId: string }>(
+  const [, params] = useRoute<{ stockLocationId?: string }>(
     appRoutes.stockLocation.path
   )
 
   const stockLocationId = params?.stockLocationId ?? ''
 
-  const { stockLocation, isLoading, error } =
-    useStockLocationDetails(stockLocationId)
+  const stockLocationDetails = useStockLocationDetails(stockLocationId)
+  const { stockLocation, isLoading, error } = stockLocationDetails ?? null
 
   const queryString = useSearch()
   const [, setLocation] = useLocation()
@@ -63,7 +63,8 @@ export function StockItemsList(): JSX.Element {
     )
   }
 
-  const pageTitle = stockLocation.name
+  const pageTitle =
+    stockLocationId !== '' ? stockLocation.name : 'All inventory'
 
   if (!canUser('read', 'stock_locations')) {
     return (
@@ -102,7 +103,7 @@ export function StockItemsList(): JSX.Element {
       <FilteredList
         type='stock_items'
         query={{
-          include: ['sku', 'reserved_stock'],
+          include: ['sku', 'reserved_stock', 'stock_location'],
           sort: {
             created_at: 'desc'
           }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Add `All inventory` page in `inventory` app to show the full list of stock items without any stock location constraint.
This change caused several changes in app's navigation and forms to support the old stock location based navigation in a sort of optional way of the stock location URL level.
In addition, when a `stock item` is created from the `All inventory` page a new `stock location` select is shown in order to set the required stock location information.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
