### PR TITLE
Add `All prices` page in `price_lists` app

### DIFF
--- a/apps/price_lists/src/components/ListItemPrice.tsx
+++ b/apps/price_lists/src/components/ListItemPrice.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   Badge,
   ListItem,
+  Spacer,
   Text,
   withSkeletonTemplate
 } from '@commercelayer/app-elements'
@@ -59,6 +60,13 @@ export const ListItemPrice = withSkeletonTemplate<Props>(
           <Text tag='div' weight='semibold'>
             {resource.sku?.name}
           </Text>
+          {priceListId === '' && (
+            <Spacer bottom='2'>
+              <Text tag='div' weight='medium' variant='info' size='small'>
+                {resource.price_list?.name}
+              </Text>
+            </Spacer>
+          )}
           {hasPriceTiers && (
             <div className='flex items-center gap-2 mt-1'>
               {hasFrequencyPriceTiers && (

--- a/apps/price_lists/src/components/ListItemPrice.tsx
+++ b/apps/price_lists/src/components/ListItemPrice.tsx
@@ -61,7 +61,7 @@ export const ListItemPrice = withSkeletonTemplate<Props>(
             {resource.sku?.name}
           </Text>
           {priceListId === '' && (
-            <Spacer bottom='2'>
+            <Spacer bottom={hasPriceTiers ? '2' : undefined}>
               <Text tag='div' weight='medium' variant='info' size='small'>
                 {resource.price_list?.name}
               </Text>

--- a/apps/price_lists/src/components/ListItemSku.tsx
+++ b/apps/price_lists/src/components/ListItemSku.tsx
@@ -50,7 +50,7 @@ export const ListItemSku = withSkeletonTemplate<Props>(
         {variant === 'boxed' && !disabled && (
           <Icon
             name='pencilSimple'
-            size='18'
+            size='16'
             weight='bold'
             className='text-primary'
           />

--- a/apps/price_lists/src/components/PriceForm.tsx
+++ b/apps/price_lists/src/components/PriceForm.tsx
@@ -4,9 +4,8 @@ import {
   Button,
   HookedForm,
   HookedInputCurrency,
+  HookedInputSelect,
   HookedValidationApiError,
-  HookedValidationError,
-  InputSelect,
   Section,
   Spacer,
   Text,
@@ -95,7 +94,8 @@ export function PriceForm({
                     showAddItemOverlay({ type: 'skus' })
                   }}
                 >
-                  <InputSelect
+                  <HookedInputSelect
+                    name='item'
                     initialValues={[]}
                     placeholder='Select an SKU'
                     onSelect={() => {}}
@@ -113,9 +113,6 @@ export function PriceForm({
                   }}
                 />
               )}
-              <Spacer top='2'>
-                <HookedValidationError name='item' />
-              </Spacer>
               <AddItemOverlay
                 onConfirm={(resource) => {
                   setSelectedItemResource(resource)

--- a/apps/price_lists/src/components/PriceForm.tsx
+++ b/apps/price_lists/src/components/PriceForm.tsx
@@ -24,8 +24,14 @@ const priceFormSchema = z.object({
   item: z.string().min(1),
   price_list: z.string().min(1),
   currency_code: z.string().min(1),
-  price: z.number(),
-  original_price: z.number()
+  price: z.number({
+    required_error: 'Required',
+    invalid_type_error: 'Expected number'
+  }),
+  original_price: z.number({
+    required_error: 'Required',
+    invalid_type_error: 'Expected number'
+  })
 })
 
 export type PriceFormValues = z.infer<typeof priceFormSchema>

--- a/apps/price_lists/src/components/PriceListSelector.tsx
+++ b/apps/price_lists/src/components/PriceListSelector.tsx
@@ -1,0 +1,114 @@
+import {
+  HookedInputSelect,
+  useCoreApi,
+  useCoreSdkProvider,
+  type InputSelectValue
+} from '@commercelayer/app-elements'
+import type { ListResponse, PriceList, Resource } from '@commercelayer/sdk'
+import isEmpty from 'lodash/isEmpty'
+import isString from 'lodash/isString'
+import { type FC } from 'react'
+import { useFormContext } from 'react-hook-form'
+
+export const PriceListSelector: FC = () => {
+  const { sdkClient } = useCoreSdkProvider()
+  const { setValue } = useFormContext()
+  const { data, isLoading: isLoadingInitialValues } = useCoreApi(
+    'price_lists',
+    'list',
+    [
+      {
+        fields: {
+          price_lists: ['name', 'currency_code']
+        },
+        pageSize: 25,
+        sort: {
+          name: 'asc'
+        }
+      }
+    ]
+  )
+
+  const hasMorePages =
+    (data?.meta?.pageCount != null && data.meta.pageCount > 1) ?? false
+
+  const initialValues = [
+    ...makeSelectInitialValuesWithDefault<PriceList>({
+      resourceList: data,
+      fieldForLabel: 'name'
+    })
+  ]
+
+  return (
+    <HookedInputSelect
+      name='price_list'
+      label='Price list'
+      placeholder='Select a price list'
+      initialValues={initialValues}
+      isLoading={isLoadingInitialValues}
+      isClearable={false}
+      isSearchable
+      onSelect={(selected) => {
+        if (isString(selected) && !isEmpty(selected)) {
+          setValue('price_list', selected)
+        }
+      }}
+      menuFooterText={
+        hasMorePages
+          ? 'Showing 25 results. Type to search for more options.'
+          : undefined
+      }
+      loadAsyncValues={
+        hasMorePages
+          ? async (hint) => {
+              return await sdkClient.price_lists
+                .list({
+                  pageSize: 25,
+                  filters: {
+                    name_cont: hint,
+                    fields: {
+                      price_lists: ['name']
+                    }
+                  }
+                })
+                .then((res) => {
+                  return res.map((priceList) => ({
+                    label: priceList.name,
+                    value: priceList.id,
+                    meta: priceList
+                  }))
+                })
+            }
+          : undefined
+      }
+    />
+  )
+}
+
+function makeSelectInitialValuesWithDefault<R extends Resource>({
+  resourceList,
+  defaultResource,
+  fieldForLabel
+}: {
+  resourceList?: ListResponse<R>
+  defaultResource?: R
+  fieldForLabel: keyof R
+}): InputSelectValue[] {
+  const options = [
+    defaultResource != null
+      ? {
+          label: (
+            defaultResource[fieldForLabel] ?? defaultResource.id
+          ).toString(),
+          value: defaultResource.id
+        }
+      : undefined,
+    ...(resourceList ?? []).map((item) => ({
+      label: (item[fieldForLabel] ?? item.id).toString(),
+      value: item.id,
+      meta: item
+    }))
+  ].filter((v) => !isEmpty(v)) as InputSelectValue[]
+
+  return options.sort((a, b) => a.label.localeCompare(b.label))
+}

--- a/apps/price_lists/src/data/routes.ts
+++ b/apps/price_lists/src/data/routes.ts
@@ -17,20 +17,20 @@ export const appRoutes = {
   home: createRoute('/'),
   priceListNew: createRoute('/new/'),
   priceListEdit: createRoute('/:priceListId/edit/'),
-  pricesList: createRoute('/:priceListId/list/'),
-  priceNew: createRoute('/:priceListId/list/new/'),
-  priceDetails: createRoute('/:priceListId/list/:priceId/'),
-  priceEdit: createRoute('/:priceListId/list/:priceId/edit/'),
+  pricesList: createRoute('/:priceListId?/list/'),
+  priceNew: createRoute('/:priceListId?/list/new/'),
+  priceDetails: createRoute('/:priceListId?/list/:priceId/'),
+  priceEdit: createRoute('/:priceListId?/list/:priceId/edit/'),
   priceVolumeTierNew: createRoute(
-    '/:priceListId/list/:priceId/volume-tiers/new/'
+    '/:priceListId?/list/:priceId/volume-tiers/new/'
   ),
   priceFrequencyTierNew: createRoute(
-    '/:priceListId/list/:priceId/frequency-tiers/new/'
+    '/:priceListId?/list/:priceId/frequency-tiers/new/'
   ),
   priceVolumeTierEdit: createRoute(
-    '/:priceListId/list/:priceId/volume-tiers/:tierId/edit/'
+    '/:priceListId?/list/:priceId/volume-tiers/:tierId/edit/'
   ),
   priceFrequencyTierEdit: createRoute(
-    '/:priceListId/list/:priceId/frequency-tiers/:tierId/edit/'
+    '/:priceListId?/list/:priceId/frequency-tiers/:tierId/edit/'
   )
 }

--- a/apps/price_lists/src/hooks/usePriceDetails.tsx
+++ b/apps/price_lists/src/hooks/usePriceDetails.tsx
@@ -21,7 +21,12 @@ export function usePriceDetails(id: string): {
       ? [
           id,
           {
-            include: ['sku', 'price_volume_tiers', 'price_frequency_tiers']
+            include: [
+              'sku',
+              'price_volume_tiers',
+              'price_frequency_tiers',
+              'price_list'
+            ]
           }
         ]
       : null,

--- a/apps/price_lists/src/hooks/usePriceListDetails.tsx
+++ b/apps/price_lists/src/hooks/usePriceListDetails.tsx
@@ -14,9 +14,14 @@ export function usePriceListDetails(id: string): {
     isLoading,
     error,
     mutate: mutatePriceList
-  } = useCoreApi('price_lists', 'retrieve', !isMockedId(id) ? [id] : null, {
-    fallbackData: makePriceList()
-  })
+  } = useCoreApi(
+    'price_lists',
+    'retrieve',
+    id !== '' && !isMockedId(id) ? [id] : null,
+    {
+      fallbackData: makePriceList()
+    }
+  )
 
   return { priceList, error, isLoading, mutatePriceList }
 }

--- a/apps/price_lists/src/pages/PriceDetails.tsx
+++ b/apps/price_lists/src/pages/PriceDetails.tsx
@@ -18,6 +18,7 @@ import { PriceInfo } from '#components/PriceInfo'
 import { PriceTiers } from '#components/PriceTiers'
 import { appRoutes } from '#data/routes'
 import { usePriceDetails } from '#hooks/usePriceDetails'
+import { usePriceListDetails } from '#hooks/usePriceListDetails'
 import { useState } from 'react'
 
 export function PriceDetails(): JSX.Element {
@@ -35,6 +36,7 @@ export function PriceDetails(): JSX.Element {
   const priceId = params?.priceId ?? ''
 
   const { price, isLoading, error, mutatePrice } = usePriceDetails(priceId)
+  const { priceList } = usePriceListDetails(priceListId)
 
   const { sdkClient } = useCoreSdkProvider()
 
@@ -114,7 +116,7 @@ export function PriceDetails(): JSX.Element {
             defaultRelativePath: appRoutes.pricesList.makePath({ priceListId })
           })
         },
-        label: 'Prices',
+        label: priceListId !== '' ? priceList.name : 'Prices',
         icon: 'arrowLeft'
       }}
       toolbar={pageToolbar}

--- a/apps/price_lists/src/pages/PriceEdit.tsx
+++ b/apps/price_lists/src/pages/PriceEdit.tsx
@@ -84,7 +84,8 @@ export function PriceEdit(): JSX.Element {
               currency_code: price.currency_code?.toString(),
               price: price.amount_cents,
               original_price: price.compare_at_amount_cents ?? 0,
-              item: price.sku?.id
+              item: price.sku?.id,
+              price_list: price.price_list?.id
             }}
             apiError={apiError}
             isSubmitting={isSaving}

--- a/apps/price_lists/src/pages/PriceNew.tsx
+++ b/apps/price_lists/src/pages/PriceNew.tsx
@@ -1,6 +1,5 @@
 import { PriceForm, type PriceFormValues } from '#components/PriceForm'
 import { appRoutes } from '#data/routes'
-import { usePriceListDetails } from '#hooks/usePriceListDetails'
 import {
   Button,
   EmptyState,
@@ -14,10 +13,7 @@ import { useState } from 'react'
 import { Link, useLocation, useRoute } from 'wouter'
 
 export function PriceNew(): JSX.Element {
-  const {
-    canUser,
-    settings: { mode }
-  } = useTokenProvider()
+  const { canUser } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const [, setLocation] = useLocation()
 
@@ -27,33 +23,7 @@ export function PriceNew(): JSX.Element {
   const [, params] = useRoute<{ priceListId: string }>(appRoutes.priceNew.path)
   const priceListId = params?.priceListId ?? ''
 
-  const { priceList, error } = usePriceListDetails(priceListId)
   const pageTitle = 'New price'
-
-  if (error != null) {
-    return (
-      <PageLayout
-        title={pageTitle}
-        navigationButton={{
-          onClick: () => {
-            setLocation(appRoutes.home.makePath({}))
-          },
-          label: pageTitle,
-          icon: 'arrowLeft'
-        }}
-        mode={mode}
-      >
-        <EmptyState
-          title='Not authorized'
-          action={
-            <Link href={appRoutes.home.makePath({})}>
-              <Button variant='primary'>Go back</Button>
-            </Link>
-          }
-        />
-      </PageLayout>
-    )
-  }
 
   const goBackUrl = appRoutes.pricesList.makePath({ priceListId })
 
@@ -101,7 +71,11 @@ export function PriceNew(): JSX.Element {
       <Spacer bottom='14'>
         <PriceForm
           defaultValues={{
-            currency_code: priceList.currency_code
+            ...(priceListId !== ''
+              ? {
+                  price_list: priceListId
+                }
+              : {})
           }}
           apiError={apiError}
           isSubmitting={isSaving}
@@ -141,7 +115,7 @@ function adaptFormValuesToPrice(
       type: 'skus'
     },
     price_list: {
-      id: priceListId,
+      id: formValues.price_list ?? priceListId,
       type: 'price_lists'
     }
   }

--- a/apps/price_lists/src/pages/PricesList.tsx
+++ b/apps/price_lists/src/pages/PricesList.tsx
@@ -74,7 +74,7 @@ export function PricesList(): JSX.Element {
     dropdownItems: []
   }
 
-  if (canUser('update', 'price_lists')) {
+  if (canUser('update', 'price_lists') && priceListId !== '') {
     pageToolbar.dropdownItems?.push([
       {
         label: 'Edit',
@@ -87,7 +87,7 @@ export function PricesList(): JSX.Element {
     ])
   }
 
-  if (canUser('destroy', 'price_lists')) {
+  if (canUser('destroy', 'price_lists') && priceListId !== '') {
     pageToolbar.dropdownItems?.push([
       {
         label: 'Delete',
@@ -98,7 +98,7 @@ export function PricesList(): JSX.Element {
     ])
   }
 
-  const pageTitle = priceList.name
+  const pageTitle = priceListId !== '' ? priceList.name : 'All prices'
 
   if (!canUser('read', 'price_lists') || !canUser('read', 'prices')) {
     return (
@@ -139,7 +139,12 @@ export function PricesList(): JSX.Element {
       <FilteredList
         type='prices'
         query={{
-          include: ['sku', 'price_volume_tiers', 'price_frequency_tiers'],
+          include: [
+            'sku',
+            'price_volume_tiers',
+            'price_frequency_tiers',
+            'price_list'
+          ],
           sort: {
             created_at: 'desc'
           }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Add `All prices` page in `price_lists` app to show the full list of prices without any price lists constraint.
This change caused several changes in app's navigation and forms to support the old price list based navigation in a sort of optional way at the price list URL level.
In addition, when a price is created from the All prices page a new price list select is shown in order to set the required price list information and update the currency code used to configure the price and origina price fields.
## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
