### PR TITLE
New order and edit order from orders app can add bundles without a market

### DIFF
--- a/apps/orders/src/components/OrderSummary/hooks/useAddItemOverlay.tsx
+++ b/apps/orders/src/components/OrderSummary/hooks/useAddItemOverlay.tsx
@@ -41,8 +41,25 @@ export function useAddItemOverlay(order: Order): OverlayHook {
       label: 'Markets',
       type: 'options',
       sdk: {
-        predicate: 'market_id_eq',
+        predicate: 'market_id_eq_or_null',
         defaultOptions: order.market?.id != null ? [order.market?.id] : []
+      },
+      hidden: true,
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: []
+        }
+      }
+    })
+
+    instructions.push({
+      label: 'Currency code',
+      type: 'options',
+      sdk: {
+        predicate: 'currency_code_eq',
+        defaultOptions: order.currency_code != null ? [order.currency_code] : []
       },
       hidden: true,
       render: {


### PR DESCRIPTION
## What I did

New order and edit order from orders app can add bundles without a market.

## How to test

1. [app-bundles] - Create a bundle without selecting a Market
    <img width="666" alt="Screenshot 2024-10-24 alle 20 54 27" src="https://github.com/user-attachments/assets/bdfb4dcd-fff8-431f-8bf0-160e3b5d23f2">

2. [app-orders] - Create a new order within a Market with same currency code.
3. [app-orders] - Select "Add a bundle". The bundle is now visible and selectable.
