### PR TITLE
Add `subscriptions` filters

### DIFF
--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "cronstrue": "^2.50.0",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.1",
     "rollup-plugin-external-globals": "^0.12.0",

--- a/apps/subscriptions/src/App.tsx
+++ b/apps/subscriptions/src/App.tsx
@@ -1,5 +1,6 @@
 import { ErrorNotFound } from '#components/ErrorNotFound'
 import { appRoutes } from '#data/routes'
+import { Filters } from '#pages/Filters'
 import { SubscriptionsList } from '#pages/SubscriptionsList'
 import type { FC } from 'react'
 import { Route, Router, Switch } from 'wouter'
@@ -14,6 +15,9 @@ export const App: FC<AppProps> = ({ routerBase }) => {
       <Switch>
         <Route path={appRoutes.list.path}>
           <SubscriptionsList />
+        </Route>
+        <Route path={appRoutes.filters.path}>
+          <Filters />
         </Route>
         <Route>
           <ErrorNotFound />

--- a/apps/subscriptions/src/components/ListEmptyState.tsx
+++ b/apps/subscriptions/src/components/ListEmptyState.tsx
@@ -1,0 +1,60 @@
+import {
+  A,
+  Button,
+  EmptyState,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import { Link } from 'wouter'
+
+interface Props {
+  scope?: 'history' | 'userFiltered'
+}
+
+export function ListEmptyState({ scope = 'history' }: Props): JSX.Element {
+  const { canUser } = useTokenProvider()
+
+  if (scope === 'userFiltered') {
+    return (
+      <EmptyState
+        title='No subscriptions found!'
+        description={
+          <div>
+            <p>We didn't find any subscription matching the current search.</p>
+          </div>
+        }
+      />
+    )
+  }
+
+  if (canUser('create', 'order_subscriptions')) {
+    return (
+      <EmptyState
+        title='No subscriptions yet!'
+        description='Create your first subscription'
+        action={
+          <Link href='#'>
+            <Button variant='primary'>New subscription</Button>
+          </Link>
+        }
+      />
+    )
+  }
+
+  return (
+    <EmptyState
+      title='No subscriptions yet!'
+      description={
+        <div>
+          <p>Add a subscription with the API, or use the CLI.</p>
+          <A
+            target='_blank'
+            href='https://docs.commercelayer.io/core/v/api-reference/order_subscriptions'
+            rel='noreferrer'
+          >
+            View API reference.
+          </A>
+        </div>
+      }
+    />
+  )
+}

--- a/apps/subscriptions/src/data/filters.ts
+++ b/apps/subscriptions/src/data/filters.ts
@@ -1,70 +1,82 @@
 import type { FiltersInstructions } from '@commercelayer/app-elements'
-import { frequencies } from './frequencies'
+import { frequenciesForFilters, getFrequencyLabelByValue } from './frequencies'
 
-export const instructions: FiltersInstructions = [
-  {
-    label: 'Markets',
-    type: 'options',
-    sdk: {
-      predicate: 'market_id_in'
-    },
-    render: {
-      component: 'inputResourceGroup',
-      props: {
-        fieldForLabel: 'name',
-        fieldForValue: 'id',
-        resource: 'markets',
-        searchBy: 'name_cont',
-        sortBy: { attribute: 'name', direction: 'asc' },
-        previewLimit: 5,
-        filters: {
-          disabled_at_null: true
+export const instructions = (
+  subscriptionModelFrequencies?: string[]
+): FiltersInstructions => {
+  const frequenciesByModel = subscriptionModelFrequencies?.map((f) => {
+    return {
+      value: f,
+      label: getFrequencyLabelByValue(f)
+    }
+  })
+  const frequencies = frequenciesForFilters()
+
+  return [
+    {
+      label: 'Markets',
+      type: 'options',
+      sdk: {
+        predicate: 'market_id_in'
+      },
+      render: {
+        component: 'inputResourceGroup',
+        props: {
+          fieldForLabel: 'name',
+          fieldForValue: 'id',
+          resource: 'markets',
+          searchBy: 'name_cont',
+          sortBy: { attribute: 'name', direction: 'asc' },
+          previewLimit: 5,
+          filters: {
+            disabled_at_null: true
+          }
         }
       }
-    }
-  },
-  {
-    label: 'Status',
-    type: 'options',
-    sdk: {
-      predicate: 'status_in'
     },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: [
-          { value: 'draft', label: 'Draft' },
-          { value: 'active', label: 'Active' },
-          { value: 'inactive', label: 'Inactive' },
-          { value: 'cancelled', label: 'Cancelled' }
-        ]
+    {
+      label: 'Status',
+      type: 'options',
+      sdk: {
+        predicate: 'status_in'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: [
+            { value: 'draft', label: 'Draft' },
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+            { value: 'cancelled', label: 'Cancelled' }
+          ]
+        }
       }
-    }
-  },
-  {
-    label: 'Frequency',
-    type: 'options',
-    sdk: {
-      predicate: 'frequency_in'
     },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: frequencies
+    {
+      label: 'Frequency',
+      type: 'options',
+      sdk: {
+        predicate: 'frequency_matches'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'single',
+          options: frequenciesByModel ?? frequencies
+        }
       }
-    }
-  },
+    },
 
-  {
-    label: 'Search',
-    type: 'textSearch',
-    sdk: {
-      predicate: ['number', 'customer_email'].join('_or_') + '_cont'
-    },
-    render: {
-      component: 'searchBar'
+    {
+      label: 'Search',
+      type: 'textSearch',
+      sdk: {
+        predicate: ['number', 'customer_email'].join('_or_') + '_cont'
+      },
+      render: {
+        component: 'searchBar'
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/subscriptions/src/data/filters.ts
+++ b/apps/subscriptions/src/data/filters.ts
@@ -1,4 +1,5 @@
 import type { FiltersInstructions } from '@commercelayer/app-elements'
+import { frequencies } from './frequencies'
 
 export const instructions: FiltersInstructions = [
   {
@@ -51,44 +52,7 @@ export const instructions: FiltersInstructions = [
       component: 'inputToggleButton',
       props: {
         mode: 'multi',
-        options: [
-          {
-            value: 'hourly',
-            label: 'Hourly'
-          },
-          {
-            value: 'daily',
-            label: 'Daily'
-          },
-          {
-            value: 'weekly',
-            label: 'Weekly'
-          },
-          {
-            value: 'monthly',
-            label: 'Monthly'
-          },
-          {
-            value: 'two-month',
-            label: '2-Month'
-          },
-          {
-            value: 'three-month',
-            label: '3-Month'
-          },
-          {
-            value: 'four-month',
-            label: '4-Month'
-          },
-          {
-            value: 'six-month',
-            label: '6-Month'
-          },
-          {
-            value: 'yearly',
-            label: 'Yearly'
-          }
-        ]
+        options: frequencies
       }
     }
   },

--- a/apps/subscriptions/src/data/filters.ts
+++ b/apps/subscriptions/src/data/filters.ts
@@ -1,0 +1,106 @@
+import type { FiltersInstructions } from '@commercelayer/app-elements'
+
+export const instructions: FiltersInstructions = [
+  {
+    label: 'Markets',
+    type: 'options',
+    sdk: {
+      predicate: 'market_id_in'
+    },
+    render: {
+      component: 'inputResourceGroup',
+      props: {
+        fieldForLabel: 'name',
+        fieldForValue: 'id',
+        resource: 'markets',
+        searchBy: 'name_cont',
+        sortBy: { attribute: 'name', direction: 'asc' },
+        previewLimit: 5,
+        filters: {
+          disabled_at_null: true
+        }
+      }
+    }
+  },
+  {
+    label: 'Status',
+    type: 'options',
+    sdk: {
+      predicate: 'status_in'
+    },
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'multi',
+        options: [
+          { value: 'draft', label: 'Draft' },
+          { value: 'active', label: 'Active' },
+          { value: 'inactive', label: 'Inactive' },
+          { value: 'cancelled', label: 'Cancelled' }
+        ]
+      }
+    }
+  },
+  {
+    label: 'Frequency',
+    type: 'options',
+    sdk: {
+      predicate: 'frequency_in'
+    },
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'multi',
+        options: [
+          {
+            value: 'hourly',
+            label: 'Hourly'
+          },
+          {
+            value: 'daily',
+            label: 'Daily'
+          },
+          {
+            value: 'weekly',
+            label: 'Weekly'
+          },
+          {
+            value: 'monthly',
+            label: 'Monthly'
+          },
+          {
+            value: 'two-month',
+            label: '2-Month'
+          },
+          {
+            value: 'three-month',
+            label: '3-Month'
+          },
+          {
+            value: 'four-month',
+            label: '4-Month'
+          },
+          {
+            value: 'six-month',
+            label: '6-Month'
+          },
+          {
+            value: 'yearly',
+            label: 'Yearly'
+          }
+        ]
+      }
+    }
+  },
+
+  {
+    label: 'Search',
+    type: 'textSearch',
+    sdk: {
+      predicate: ['number', 'customer_email'].join('_or_') + '_cont'
+    },
+    render: {
+      component: 'searchBar'
+    }
+  }
+]

--- a/apps/subscriptions/src/data/frequencies.ts
+++ b/apps/subscriptions/src/data/frequencies.ts
@@ -1,3 +1,6 @@
+import cronstrue from 'cronstrue'
+import 'cronstrue/locales/en'
+
 interface SelectableFrequency {
   label: string
   value: string
@@ -83,4 +86,5 @@ export const frequenciesForFilters = (): SelectableFrequency[] => {
  * @returns a string containing either the calculated label or the value itself if the label is not found.
  */
 export const getFrequencyLabelByValue = (value: string): string =>
-  frequenciesTranslations.find((f) => f.value === value)?.label ?? value
+  frequenciesTranslations.find((f) => f.value === value)?.label ??
+  cronstrue.toString(value)

--- a/apps/subscriptions/src/data/frequencies.ts
+++ b/apps/subscriptions/src/data/frequencies.ts
@@ -1,0 +1,38 @@
+export const frequencies = [
+  {
+    value: 'hourly',
+    label: 'Hourly'
+  },
+  {
+    value: 'daily',
+    label: 'Daily'
+  },
+  {
+    value: 'weekly',
+    label: 'Weekly'
+  },
+  {
+    value: 'monthly',
+    label: 'Monthly'
+  },
+  {
+    value: 'two-month',
+    label: 'Every two months'
+  },
+  {
+    value: 'three-month',
+    label: 'Every three months'
+  },
+  {
+    value: 'four-month',
+    label: 'Every four months'
+  },
+  {
+    value: 'six-month',
+    label: 'Every six months'
+  },
+  {
+    value: 'yearly',
+    label: 'Yearly'
+  }
+]

--- a/apps/subscriptions/src/data/frequencies.ts
+++ b/apps/subscriptions/src/data/frequencies.ts
@@ -1,4 +1,12 @@
-export const frequencies = [
+interface SelectableFrequency {
+  label: string
+  value: string
+}
+
+/**
+ * Provides a list of translated frequencies suitable for filters options.
+ */
+export const frequenciesTranslations: SelectableFrequency[] = [
   {
     value: 'hourly',
     label: 'Hourly'
@@ -20,7 +28,15 @@ export const frequencies = [
     label: 'Every two months'
   },
   {
+    value: 'two-months',
+    label: 'Every two months'
+  },
+  {
     value: 'three-month',
+    label: 'Every three months'
+  },
+  {
+    value: 'three-months',
     label: 'Every three months'
   },
   {
@@ -28,7 +44,15 @@ export const frequencies = [
     label: 'Every four months'
   },
   {
+    value: 'four-months',
+    label: 'Every four months'
+  },
+  {
     value: 'six-month',
+    label: 'Every six months'
+  },
+  {
+    value: 'six-months',
     label: 'Every six months'
   },
   {
@@ -36,3 +60,27 @@ export const frequencies = [
     label: 'Yearly'
   }
 ]
+
+/**
+ * Generate a unique list of selectable frequencies suitable for filters options.
+ */
+export const frequenciesForFilters = (): SelectableFrequency[] => {
+  const frequencies = frequenciesTranslations.reduce(
+    (acc: SelectableFrequency[], obj: SelectableFrequency) => {
+      if (!acc.some((item) => item.label === obj.label)) {
+        acc.push(obj)
+      }
+      return acc
+    },
+    []
+  )
+  return frequencies
+}
+
+/**
+ * Extract, if available, a frequency label of a given value.
+ * @param value - A given value to search for a label.
+ * @returns a string containing either the calculated label or the value itself if the label is not found.
+ */
+export const getFrequencyLabelByValue = (value: string): string =>
+  frequenciesTranslations.find((f) => f.value === value)?.label ?? value

--- a/apps/subscriptions/src/data/routes.ts
+++ b/apps/subscriptions/src/data/routes.ts
@@ -8,6 +8,7 @@ export type AppRoute = keyof typeof appRoutes
 // and `makePath` method to be used to generate the path used in navigation and links
 export const appRoutes = {
   list: createRoute('/'),
+  filters: createRoute('/filters/'),
   details: createRoute('/:subscriptionId/'),
   editSubscription: createRoute('/:subscriptionId/edit/')
 }

--- a/apps/subscriptions/src/hooks/useSubscriptionModelsFrequencies.tsx
+++ b/apps/subscriptions/src/hooks/useSubscriptionModelsFrequencies.tsx
@@ -1,0 +1,17 @@
+import { useCoreApi } from '@commercelayer/app-elements'
+import { useMemo } from 'react'
+
+export const useSubscriptionModelsFrequencies = (): string[] => {
+  const { data } = useCoreApi('subscription_models', 'list', [{ pageSize: 25 }])
+
+  return useMemo(() => {
+    if (data != null && data.meta.recordCount <= 25) {
+      const frequencies: string[] = []
+      data?.forEach((subModel) => {
+        subModel.frequencies.forEach((freq) => frequencies.push(freq))
+      })
+      return [...new Set(frequencies)]
+    }
+    return []
+  }, [data])
+}

--- a/apps/subscriptions/src/pages/Filters.tsx
+++ b/apps/subscriptions/src/pages/Filters.tsx
@@ -1,0 +1,38 @@
+import { instructions } from '#data/filters'
+import { appRoutes } from '#data/routes'
+import { PageLayout, useResourceFilters } from '@commercelayer/app-elements'
+import type { FC } from 'react'
+import { useLocation } from 'wouter'
+
+export const Filters: FC = () => {
+  const [, setLocation] = useLocation()
+  const { FiltersForm, adapters } = useResourceFilters({
+    instructions
+  })
+
+  return (
+    <PageLayout
+      title='Filters'
+      navigationButton={{
+        onClick: () => {
+          setLocation(
+            appRoutes.list.makePath(
+              adapters.adaptUrlQueryToUrlQuery({
+                queryString: location.search
+              })
+            )
+          )
+        },
+        label: 'Cancel',
+        icon: 'x'
+      }}
+      overlay
+    >
+      <FiltersForm
+        onSubmit={(filtersQueryString) => {
+          setLocation(appRoutes.list.makePath({}, filtersQueryString))
+        }}
+      />
+    </PageLayout>
+  )
+}

--- a/apps/subscriptions/src/pages/Filters.tsx
+++ b/apps/subscriptions/src/pages/Filters.tsx
@@ -1,14 +1,21 @@
 import { instructions } from '#data/filters'
 import { appRoutes } from '#data/routes'
+import { useSubscriptionModelsFrequencies } from '#hooks/useSubscriptionModelsFrequencies'
 import { PageLayout, useResourceFilters } from '@commercelayer/app-elements'
-import type { FC } from 'react'
+import { useCallback, type FC } from 'react'
 import { useLocation } from 'wouter'
 
 export const Filters: FC = () => {
   const [, setLocation] = useLocation()
-  const { FiltersForm, adapters } = useResourceFilters({
-    instructions
-  })
+  const subscriptionModelsFrequencies = useSubscriptionModelsFrequencies()
+
+  const filters = useCallback(() => {
+    return useResourceFilters({
+      instructions: instructions(subscriptionModelsFrequencies)
+    })
+  }, [subscriptionModelsFrequencies])
+
+  const { FiltersForm, adapters } = filters()
 
   return (
     <PageLayout

--- a/apps/subscriptions/src/pages/SubscriptionsList.tsx
+++ b/apps/subscriptions/src/pages/SubscriptionsList.tsx
@@ -1,28 +1,26 @@
+import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemSubscription } from '#components/ListItemSubscription'
+import { instructions } from '#data/filters'
 import { appRoutes } from '#data/routes'
 import {
   EmptyState,
   HomePageLayout,
   PageLayout,
   Spacer,
-  useResourceList,
+  useResourceFilters,
   useTokenProvider
 } from '@commercelayer/app-elements'
 import type { FC } from 'react'
 import { useLocation } from 'wouter'
+import { navigate, useSearch } from 'wouter/use-browser-location'
 
 export const SubscriptionsList: FC = () => {
   const { settings, canUser } = useTokenProvider()
   const [, setLocation] = useLocation()
-  const { ResourceList } = useResourceList({
-    type: 'order_subscriptions',
-    query: {
-      include: ['market'],
-      sort: {
-        updated_at: 'desc'
-      },
-      pageSize: 25
-    }
+  const queryString = useSearch()
+
+  const { SearchWithNav, FilteredList, hasActiveFilter } = useResourceFilters({
+    instructions
   })
 
   if (!canUser('read', 'order_subscriptions')) {
@@ -45,11 +43,35 @@ export const SubscriptionsList: FC = () => {
 
   return (
     <HomePageLayout title='Subscriptions'>
+      <SearchWithNav
+        queryString={queryString}
+        onUpdate={(qs) => {
+          navigate(`?${qs}`, {
+            replace: true
+          })
+        }}
+        onFilterClick={(queryString) => {
+          setLocation(appRoutes.filters.makePath({}, queryString))
+        }}
+        hideFiltersNav={false}
+      />
+
       <Spacer top='14'>
-        <ResourceList
-          title='All'
+        <FilteredList
+          type='order_subscriptions'
           ItemTemplate={ListItemSubscription}
-          emptyState={<EmptyState title='No subscriptions yet!' />}
+          query={{
+            include: ['market'],
+            sort: {
+              updated_at: 'desc'
+            },
+            pageSize: 25
+          }}
+          emptyState={
+            <ListEmptyState
+              scope={hasActiveFilter ? 'userFiltered' : 'history'}
+            />
+          }
         />
       </Spacer>
     </HomePageLayout>

--- a/apps/subscriptions/src/pages/SubscriptionsList.tsx
+++ b/apps/subscriptions/src/pages/SubscriptionsList.tsx
@@ -2,6 +2,7 @@ import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemSubscription } from '#components/ListItemSubscription'
 import { instructions } from '#data/filters'
 import { appRoutes } from '#data/routes'
+import { useSubscriptionModelsFrequencies } from '#hooks/useSubscriptionModelsFrequencies'
 import {
   EmptyState,
   HomePageLayout,
@@ -10,7 +11,7 @@ import {
   useResourceFilters,
   useTokenProvider
 } from '@commercelayer/app-elements'
-import type { FC } from 'react'
+import { useCallback, type FC } from 'react'
 import { useLocation } from 'wouter'
 import { navigate, useSearch } from 'wouter/use-browser-location'
 
@@ -19,9 +20,15 @@ export const SubscriptionsList: FC = () => {
   const [, setLocation] = useLocation()
   const queryString = useSearch()
 
-  const { SearchWithNav, FilteredList, hasActiveFilter } = useResourceFilters({
-    instructions
-  })
+  const subscriptionModelsFrequencies = useSubscriptionModelsFrequencies()
+
+  const filters = useCallback(() => {
+    return useResourceFilters({
+      instructions: instructions(subscriptionModelsFrequencies)
+    })
+  }, [subscriptionModelsFrequencies])
+
+  const { SearchWithNav, FilteredList, hasActiveFilter } = filters()
 
   if (!canUser('read', 'order_subscriptions')) {
     return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1253,6 +1253,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.3.3(vite@5.4.10(@types/node@22.7.7))
+      cronstrue:
+        specifier: ^2.50.0
+        version: 2.51.0
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -3025,6 +3028,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cronstrue@2.51.0:
+    resolution: {integrity: sha512-7EG9VaZZ5SRbZ7m25dmP6xaS0qe9ay6wywMskFOU/lMDKa+3gZr2oeT5OUfXwRP/Bcj8wxdYJ65AHU70CI3tsw==}
+    hasBin: true
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -7599,6 +7606,8 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.6.3
+
+  cronstrue@2.51.0: {}
 
   cross-spawn@7.0.3:
     dependencies:


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added filters in home page of `subscriptions` app.
Frequency filters are calculated by generating a unique list of frequencies from organization's `subscription_models` and then used relying on the `frequency_matches` filter type.

<img width="600" alt="Screenshot 2024-10-29 alle 17 33 45" src="https://github.com/user-attachments/assets/63797cb7-e9e2-4d33-a9ab-da44ae643932">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
