### PR TITLE
Possibility to set up the shipping and billing addresses from the order creation page

### DIFF
--- a/apps/orders/src/components/OrderAddresses.tsx
+++ b/apps/orders/src/components/OrderAddresses.tsx
@@ -2,6 +2,7 @@ import {
   ResourceAddress,
   Section,
   Stack,
+  useCoreSdkProvider,
   withSkeletonTemplate
 } from '@commercelayer/app-elements'
 import type { Order } from '@commercelayer/sdk'
@@ -12,28 +13,41 @@ interface Props {
 
 export const OrderAddresses = withSkeletonTemplate<Props>(
   ({ order }): JSX.Element | null => {
-    if (order.shipping_address == null && order.billing_address == null) {
-      return null
-    }
+    const { sdkClient } = useCoreSdkProvider()
 
     return (
       <Section border='none' title='Addresses'>
         <Stack>
-          {order.billing_address != null && (
-            <ResourceAddress
-              title='Billing address'
-              address={order.billing_address}
-              showBillingInfo
-              editable
-            />
-          )}
-          {order.shipping_address != null && (
-            <ResourceAddress
-              title='Shipping address'
-              address={order.shipping_address}
-              editable
-            />
-          )}
+          <ResourceAddress
+            title='Billing address'
+            address={order.billing_address}
+            editable
+            onCreate={(address) => {
+              void sdkClient.orders.update({
+                id: order.id,
+                billing_address: {
+                  type: 'addresses',
+                  id: address.id
+                }
+              })
+            }}
+            showBillingInfo
+            requiresBillingInfo={order.requires_billing_info ?? undefined}
+          />
+          <ResourceAddress
+            title='Shipping address'
+            address={order.shipping_address}
+            editable
+            onCreate={(address) => {
+              void sdkClient.orders.update({
+                id: order.id,
+                shipping_address: {
+                  type: 'addresses',
+                  id: address.id
+                }
+              })
+            }}
+          />
         </Stack>
       </Section>
     )


### PR DESCRIPTION
Closes commercelayer/issues-app#234 commercelayer/issues-app#91

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Now is possible to set up the shipping and billing addresses directly from the order creation page.
