### PR TITLE
Improve UI/UX for package selector in shipments app

### DIFF
--- a/apps/shipments/src/components/ShipmentSteps.tsx
+++ b/apps/shipments/src/components/ShipmentSteps.tsx
@@ -61,6 +61,7 @@ export const ShipmentSteps = withSkeletonTemplate<Props>(
 function getBadgeVariant(shipment: Shipment): BadgeProps['variant'] {
   switch (shipment.status) {
     case 'picking':
+    case 'packing':
     case 'ready_to_ship':
     case 'on_hold':
       return 'warning-solid'

--- a/apps/shipments/src/data/packingFormSchema.ts
+++ b/apps/shipments/src/data/packingFormSchema.ts
@@ -10,9 +10,11 @@ import { z } from 'zod'
 
 export const packingFormSchema = z
   .object({
-    packageId: z.string().min(1, {
-      message: 'Please select a package'
-    }),
+    packageId: z
+      .string()
+      .optional()
+      // allow to start with an empty value
+      .refine((val) => !isEmpty(val), 'Please select a package'),
     weight: z.string().min(1, {
       message: 'Please enter a weight'
     }),

--- a/apps/shipments/src/hooks/useCreateParcel.tsx
+++ b/apps/shipments/src/hooks/useCreateParcel.tsx
@@ -34,7 +34,9 @@ export function useCreateParcel(shipmentId: string): CreateParcelHook {
           parcel = await sdkClient.parcels.create({
             weight: parseInt(formValues.weight, 10),
             unit_of_weight: formValues.unitOfWeight,
-            package: sdkClient.packages.relationship(formValues.packageId),
+            package: sdkClient.packages.relationship(
+              formValues.packageId ?? null
+            ),
             shipment: sdkClient.shipments.relationship(shipmentId),
 
             // more options

--- a/apps/shipments/src/pages/Packing.tsx
+++ b/apps/shipments/src/pages/Packing.tsx
@@ -105,7 +105,7 @@ export function Packing(): JSX.Element {
               quantity: item.quantity,
               value: item.id
             })),
-            packageId: '',
+            packageId: undefined,
             weight: '',
             unitOfWeight: undefined
           }}


### PR DESCRIPTION
Closes commercelayer/issues-app#206

## What I did

- auto select first package when is the only one
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9ab3eafe-daab-4de0-bbb5-fe49cce16413">

----

- set "packing" badge as warning variant 
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f6348dea-6215-4867-83cf-6fd54f019e51">

----

- Improve UX of the packages selector, when more than 4 packages are available to align to all others autocomplete/select
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f54fa0e3-fe9c-4924-882a-421b538697a9">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
