### PR TITLE
Fix list empty state behavior in `customers` app

### DIFF
--- a/apps/customers/src/components/ListEmptyState.tsx
+++ b/apps/customers/src/components/ListEmptyState.tsx
@@ -15,7 +15,7 @@ interface Props {
 export function ListEmptyState({ scope = 'history' }: Props): JSX.Element {
   const { canUser } = useTokenProvider()
 
-  if (scope === 'presetView') {
+  if (scope === 'history') {
     return (
       <EmptyState
         title='No customers yet!'


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/253

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed the behavior of the empty state block in customers list. Actually it was not showing the create customer button in history list where it was expected to be.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
