### PR TITLE
Replace static list with ResourceList in inventory and price_lists apps

### DIFF
--- a/apps/inventory/src/pages/Home.tsx
+++ b/apps/inventory/src/pages/Home.tsx
@@ -22,7 +22,7 @@ export function Home(): JSX.Element {
 
   const [searchValue, setSearchValue] = useState<string>()
 
-  const { list, meta, isLoading, isFirstLoading } = useResourceList({
+  const { meta, isLoading, isFirstLoading, ResourceList } = useResourceList({
     type: 'stock_locations',
     query: {
       filters: {
@@ -74,12 +74,7 @@ export function Home(): JSX.Element {
                   </ListItem>
                 </Link>
               )}
-              {list?.map((stockLocation) => (
-                <ListItemStockLocation
-                  resource={stockLocation}
-                  key={stockLocation.id}
-                />
-              ))}
+              <ResourceList ItemTemplate={ListItemStockLocation} />
             </Section>
           </SkeletonTemplate>
         )}

--- a/apps/price_lists/src/pages/Home.tsx
+++ b/apps/price_lists/src/pages/Home.tsx
@@ -22,7 +22,7 @@ export function Home(): JSX.Element {
   const { canUser } = useTokenProvider()
   const [searchValue, setSearchValue] = useState<string>()
 
-  const { list, meta, isLoading, isFirstLoading } = useResourceList({
+  const { meta, isLoading, isFirstLoading, ResourceList } = useResourceList({
     type: 'price_lists',
     query: {
       filters: {
@@ -109,9 +109,7 @@ export function Home(): JSX.Element {
                   </ListItem>
                 </Link>
               )}
-              {list?.map((priceList) => (
-                <ListItemPriceList resource={priceList} key={priceList.id} />
-              ))}
+              <ResourceList ItemTemplate={ListItemPriceList} />
             </Section>
           </SkeletonTemplate>
         )}


### PR DESCRIPTION
## What I did

This pull request refactors how resource lists are rendered in the `Home` component for both the inventory and price lists pages. The main changes include replacing the manual mapping of list items with the `ResourceList` component.

Refactoring resource list rendering:

* [`apps/inventory/src/pages/Home.tsx`](diffhunk://#diff-941af74a62bc56768558f0a00aa6a772f0546c0c726e02c91d3fe44b84a979e0L25-R25): Replaced the manual mapping of `stockLocation` items with the `ResourceList` component, using `ListItemStockLocation` as the item template. [[1]](diffhunk://#diff-941af74a62bc56768558f0a00aa6a772f0546c0c726e02c91d3fe44b84a979e0L25-R25) [[2]](diffhunk://#diff-941af74a62bc56768558f0a00aa6a772f0546c0c726e02c91d3fe44b84a979e0L77-R77)
* [`apps/price_lists/src/pages/Home.tsx`](diffhunk://#diff-4ddb8d5e130fb834de9e06c038f03f0cc4e03574714944b55b2935730dfb45cbL25-R25): Replaced the manual mapping of `priceList` items with the `ResourceList` component, using `ListItemPriceList` as the item template. [[1]](diffhunk://#diff-4ddb8d5e130fb834de9e06c038f03f0cc4e03574714944b55b2935730dfb45cbL25-R25) [[2]](diffhunk://#diff-4ddb8d5e130fb834de9e06c038f03f0cc4e03574714944b55b2935730dfb45cbL112-R112)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
