### PR TITLE
Add subscription orders table

### DIFF
--- a/apps/subscriptions/src/App.tsx
+++ b/apps/subscriptions/src/App.tsx
@@ -2,6 +2,7 @@ import { ErrorNotFound } from '#components/ErrorNotFound'
 import { appRoutes } from '#data/routes'
 import { Filters } from '#pages/Filters'
 import SubscriptionDetails from '#pages/SubscriptionDetails'
+import { SubscriptionOrders } from '#pages/SubscriptionOrders'
 import { SubscriptionsList } from '#pages/SubscriptionsList'
 import type { FC } from 'react'
 import { Redirect, Route, Router, Switch } from 'wouter'
@@ -25,6 +26,9 @@ export const App: FC<AppProps> = ({ routerBase }) => {
         </Route>
         <Route path={appRoutes.details.path}>
           <SubscriptionDetails />
+        </Route>
+        <Route path={appRoutes.orders.path}>
+          <SubscriptionOrders />
         </Route>
         <Route>
           <ErrorNotFound />

--- a/apps/subscriptions/src/components/ListItemSubscriptionOrder.tsx
+++ b/apps/subscriptions/src/components/ListItemSubscriptionOrder.tsx
@@ -1,0 +1,74 @@
+import { makeOrder } from '#mocks'
+import {
+  Badge,
+  formatDate,
+  navigateTo,
+  Td,
+  Text,
+  Tr,
+  useTokenProvider,
+  withSkeletonTemplate,
+  type BadgeProps,
+  type ResourceListItemTemplateProps
+} from '@commercelayer/app-elements'
+import type { Order } from '@commercelayer/sdk'
+import capitalize from 'lodash/capitalize'
+
+export const ListItemSubscriptionOrder = withSkeletonTemplate<
+  ResourceListItemTemplateProps<'orders'>
+>(({ resource = makeOrder() }): JSX.Element | null => {
+  const { user, settings, canAccess } = useTokenProvider()
+
+  const orderDate = formatDate({
+    isoDate: resource.placed_at ?? '',
+    format: 'date',
+    timezone: user?.timezone
+  })
+
+  const orderNumber = `#${resource?.number}`
+  const navigateToOrder = canAccess('orders')
+    ? navigateTo({
+        destination: {
+          app: 'orders',
+          resourceId: resource?.id,
+          mode: settings.mode
+        }
+      })
+    : {}
+
+  const paymentStatus = capitalize(
+    resource?.payment_status.replace(/_|-/gm, ' ')
+  )
+  const paymentStatusVariant = getPaymentStatusVariant(resource?.payment_status)
+
+  return (
+    <Tr>
+      <Td>
+        <Text>{orderDate}</Text>
+      </Td>
+      <Td>
+        {canAccess('orders') ? (
+          <a {...navigateToOrder}>{`${orderNumber}`}</a>
+        ) : (
+          `${orderNumber}`
+        )}
+      </Td>
+      <Td>
+        <Badge variant={paymentStatusVariant}>{paymentStatus}</Badge>
+      </Td>
+    </Tr>
+  )
+})
+
+const getPaymentStatusVariant = (
+  status: Order['payment_status']
+): BadgeProps['variant'] => {
+  switch (status) {
+    case 'paid':
+      return 'success'
+    case 'unpaid':
+      return 'danger'
+    default:
+      return 'secondary'
+  }
+}

--- a/apps/subscriptions/src/components/SubscriptionOrders.tsx
+++ b/apps/subscriptions/src/components/SubscriptionOrders.tsx
@@ -1,12 +1,18 @@
 import { ListItemSubscriptionOrder } from '#components/ListItemSubscriptionOrder'
+import { appRoutes } from '#data/routes'
 import {
+  Button,
+  Icon,
   Section,
+  Table,
   Td,
+  Th,
   Tr,
   useResourceList,
   withSkeletonTemplate
 } from '@commercelayer/app-elements'
 import type { OrderSubscription } from '@commercelayer/sdk'
+import { useLocation } from 'wouter'
 
 interface Props {
   subscription: OrderSubscription
@@ -14,39 +20,63 @@ interface Props {
 
 export const SubscriptionOrders = withSkeletonTemplate<Props>(
   ({ subscription }) => {
-    const { ResourceList } = useResourceList({
+    const { list, meta } = useResourceList({
       type: 'orders',
       query: {
         filters: {
           order_subscription_id_eq: subscription.id,
           status_eq: 'placed'
         },
-        sort: ['-placed_at']
+        sort: ['-placed_at'],
+        pageSize: 5
       }
     })
 
+    const showAll = meta != null ? meta.pageCount > 1 : false
+    const [, setLocation] = useLocation()
+    const noResults = meta != null ? meta.recordCount === 0 : true
+
     return (
-      <Section title='Recurring orders' border='none'>
-        <ResourceList
-          variant='table'
-          headings={[
-            {
-              label: 'DATE'
-            },
-            {
-              label: 'ORDER',
-              align: 'left'
-            },
-            {
-              label: 'PAYMENT STATUS'
-            }
-          ]}
-          emptyState={
+      <Section
+        title={`Recurring orders · ${meta?.recordCount}`}
+        border='none'
+        actionButton={
+          showAll && (
+            <Button
+              variant='secondary'
+              size='mini'
+              onClick={() => {
+                setLocation(
+                  appRoutes.orders.makePath({ subscriptionId: subscription.id })
+                )
+              }}
+              alignItems='center'
+            >
+              <Icon name='eye' size={16} />
+              See all
+            </Button>
+          )
+        }
+      >
+        <Table
+          thead={
             <Tr>
-              <Td colSpan={3}>no results</Td>
+              <Th>Date</Th>
+              <Th>Order</Th>
+              <Th>Result</Th>
             </Tr>
           }
-          ItemTemplate={ListItemSubscriptionOrder}
+          tbody={
+            noResults ? (
+              <Tr>
+                <Td colSpan={3}>no results</Td>
+              </Tr>
+            ) : (
+              list?.map((order, idx) => (
+                <ListItemSubscriptionOrder resource={order} key={idx} />
+              ))
+            )
+          }
         />
       </Section>
     )

--- a/apps/subscriptions/src/components/SubscriptionOrders.tsx
+++ b/apps/subscriptions/src/components/SubscriptionOrders.tsx
@@ -1,0 +1,54 @@
+import { ListItemSubscriptionOrder } from '#components/ListItemSubscriptionOrder'
+import {
+  Section,
+  Td,
+  Tr,
+  useResourceList,
+  withSkeletonTemplate
+} from '@commercelayer/app-elements'
+import type { OrderSubscription } from '@commercelayer/sdk'
+
+interface Props {
+  subscription: OrderSubscription
+}
+
+export const SubscriptionOrders = withSkeletonTemplate<Props>(
+  ({ subscription }) => {
+    const { ResourceList } = useResourceList({
+      type: 'orders',
+      query: {
+        filters: {
+          order_subscription_id_eq: subscription.id,
+          status_eq: 'placed'
+        },
+        sort: ['-placed_at']
+      }
+    })
+
+    return (
+      <Section title='Recurring orders' border='none'>
+        <ResourceList
+          variant='table'
+          headings={[
+            {
+              label: 'DATE'
+            },
+            {
+              label: 'ORDER',
+              align: 'left'
+            },
+            {
+              label: 'PAYMENT STATUS'
+            }
+          ]}
+          emptyState={
+            <Tr>
+              <Td colSpan={3}>no results</Td>
+            </Tr>
+          }
+          ItemTemplate={ListItemSubscriptionOrder}
+        />
+      </Section>
+    )
+  }
+)

--- a/apps/subscriptions/src/data/routes.ts
+++ b/apps/subscriptions/src/data/routes.ts
@@ -11,5 +11,6 @@ export const appRoutes = {
   list: createRoute('/list/'),
   filters: createRoute('/filters/'),
   details: createRoute('/list/:subscriptionId/'),
+  orders: createRoute('/list/:subscriptionId/orders/'),
   editSubscription: createRoute('/list/:subscriptionId/edit/')
 }

--- a/apps/subscriptions/src/mocks/index.ts
+++ b/apps/subscriptions/src/mocks/index.ts
@@ -1,5 +1,6 @@
 import type { Resource } from '@commercelayer/sdk'
 
+export * from './resources/orders'
 export * from './resources/orderSubscriptionItems'
 export * from './resources/orderSubscriptions'
 

--- a/apps/subscriptions/src/mocks/resources/orders.ts
+++ b/apps/subscriptions/src/mocks/resources/orders.ts
@@ -1,0 +1,27 @@
+import type { Order } from '@commercelayer/sdk'
+import { makeResource } from '../resource'
+
+export const makeOrder = (): Order => {
+  return {
+    ...makeResource('orders'),
+    status: 'draft',
+    payment_status: 'unpaid',
+    fulfillment_status: 'unfulfilled',
+    subtotal_amount_cents: 14160,
+    formatted_subtotal_amount: '$141.60',
+    discount_amount_cents: 0,
+    formatted_discount_amount: '$0.00',
+    adjustment_amount_cents: 0,
+    formatted_adjustment_amount: '$0.00',
+    shipping_amount_cents: 1200,
+    formatted_shipping_amount: '$12.00',
+    payment_method_amount_cents: 1000,
+    formatted_payment_method_amount: '$10.00',
+    total_tax_amount_cents: 3115,
+    formatted_total_tax_amount: '$31.15',
+    gift_card_amount_cents: 0,
+    formatted_gift_card_amount: '$0.00',
+    total_amount_cents: 16360,
+    formatted_total_amount: '$163.60'
+  }
+}

--- a/apps/subscriptions/src/pages/SubscriptionDetails.tsx
+++ b/apps/subscriptions/src/pages/SubscriptionDetails.tsx
@@ -1,6 +1,7 @@
 import { SubscriptionAddresses } from '#components/SubscriptionAddresses'
 import { SubscriptionInfo } from '#components/SubscriptionInfo'
 import { SubscriptionItems } from '#components/SubscriptionItems'
+import { SubscriptionOrders } from '#components/SubscriptionOrders'
 import { SubscriptionPayment } from '#components/SubscriptionPayment'
 import { SubscriptionSteps } from '#components/SubscriptionSteps'
 import { appRoutes } from '#data/routes'
@@ -130,12 +131,9 @@ function SubscriptionDetails(): JSX.Element {
           <Spacer top='14'>
             <SubscriptionPayment subscription={subscription} />
           </Spacer>
-          {/* <Spacer top='14'>
-            <OrderPayment order={order} />
-          </Spacer>
           <Spacer top='14'>
-            <OrderAddresses order={order} />
-          </Spacer> */}
+            <SubscriptionOrders subscription={subscription} />
+          </Spacer>
           <Spacer top='14'>
             <ResourceDetails
               resource={subscription}

--- a/apps/subscriptions/src/pages/SubscriptionOrders.tsx
+++ b/apps/subscriptions/src/pages/SubscriptionOrders.tsx
@@ -1,0 +1,109 @@
+import {
+  Button,
+  EmptyState,
+  PageLayout,
+  Spacer,
+  Td,
+  Tr,
+  useResourceList,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import { Link, useLocation, useRoute } from 'wouter'
+
+import { ListItemSubscriptionOrder } from '#components/ListItemSubscriptionOrder'
+import { appRoutes } from '#data/routes'
+import { useSubscriptionDetails } from '#hooks/useSubscriptionDetails'
+import { getSubscriptionTitle } from '#utils/getSubscriptionTitle'
+
+export function SubscriptionOrders(): JSX.Element {
+  const { canUser } = useTokenProvider()
+  const [, setLocation] = useLocation()
+  const [, params] = useRoute<{ subscriptionId: string }>(appRoutes.orders.path)
+  const subscriptionId = params?.subscriptionId ?? ''
+
+  const { subscription } = useSubscriptionDetails(subscriptionId)
+  const pageTitle = getSubscriptionTitle(subscription)
+
+  const { ResourceList, isFirstLoading } = useResourceList({
+    type: 'orders',
+    query: {
+      filters: {
+        order_subscription_id_eq: subscriptionId,
+        status_eq: 'placed'
+      },
+      sort: ['-placed_at'],
+      pageSize: 5
+    }
+  })
+
+  const goBackUrl =
+    subscriptionId != null
+      ? appRoutes.details.makePath({ subscriptionId })
+      : appRoutes.list.makePath({})
+
+  if (!canUser('read', 'orders')) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        navigationButton={{
+          label: 'Back',
+          icon: 'arrowLeft',
+          onClick: () => {
+            setLocation(goBackUrl)
+          }
+        }}
+        scrollToTop
+      >
+        <EmptyState
+          title='Permission Denied'
+          description='You are not authorized to access this page.'
+          action={
+            <Link href={goBackUrl}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
+  }
+
+  return (
+    <PageLayout
+      title={pageTitle}
+      navigationButton={{
+        label: 'Back',
+        icon: 'arrowLeft',
+        onClick: () => {
+          setLocation(goBackUrl)
+        }
+      }}
+      scrollToTop
+      isLoading={isFirstLoading}
+    >
+      <Spacer bottom='14'>
+        <ResourceList
+          title='Recurring orders'
+          variant='table'
+          headings={[
+            {
+              label: 'DATE'
+            },
+            {
+              label: 'ORDER',
+              align: 'left'
+            },
+            {
+              label: 'PAYMENT STATUS'
+            }
+          ]}
+          emptyState={
+            <Tr>
+              <Td colSpan={3}>no results</Td>
+            </Tr>
+          }
+          ItemTemplate={ListItemSubscriptionOrder}
+        />
+      </Spacer>
+    </PageLayout>
+  )
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added the `Recurring orders` table inside the subscription `detail` page.
The list is limited to a maximum of 5 items in detail page.
The full `Recurring orders` list, if needed, is accessible by clicking an optional `See all` button, visibile only if more then 5 orders are found.

<img width="600" alt="Screenshot 2024-11-07 alle 12 46 05" src="https://github.com/user-attachments/assets/d1abf52c-9639-47ce-9dbd-6cb0378695c1">

<img width="600" alt="Screenshot 2024-11-07 alle 12 44 30" src="https://github.com/user-attachments/assets/c5eaae7c-eb20-4632-a745-81d5c56536ee">



## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
