### PR TITLE
Add `HS Code` to SKU info block

### DIFF
--- a/apps/skus/src/components/SkuInfo.tsx
+++ b/apps/skus/src/components/SkuInfo.tsx
@@ -56,6 +56,13 @@ export const SkuInfo: FC<Props> = ({ sku = makeSku() }) => {
           </Text>
         </ListDetailsItem>
       ) : null}
+      {sku.hs_tariff_number != null ? (
+        <ListDetailsItem label='HS Code' gutter='none'>
+          <Text tag='div' weight='semibold'>
+            {sku.hs_tariff_number}
+          </Text>
+        </ListDetailsItem>
+      ) : null}
     </Section>
   )
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added `HS Code` to SKU info block.

<img width="600" alt="Screenshot 2024-11-07 alle 12 17 58" src="https://github.com/user-attachments/assets/dc8f2a9f-f983-4bd8-b965-e5e56989e891">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
