### PR TITLE
All to choose from Customer address book in an Order

### DIFF
--- a/apps/orders/src/components/NewOrder/hooks/useCustomerAddressOverlay.tsx
+++ b/apps/orders/src/components/NewOrder/hooks/useCustomerAddressOverlay.tsx
@@ -1,0 +1,176 @@
+/*
+To Do:
+1. How to handle error in handler? We have setApiError(error), but how to use this on front end?
+*/
+
+import { useCustomerDetails } from '#hooks/useCustomerDetails'
+import {
+    Alert,
+    Button,
+    Icon,
+    ListItem,
+    PageLayout,
+    ResourceAddress,
+    Section,
+    Spacer,
+    useCoreSdkProvider,
+    useOverlay,
+    withSkeletonTemplate
+} from '@commercelayer/app-elements'
+import type { Customer, Order } from '@commercelayer/sdk'
+import { useState } from 'react'
+
+interface Props {
+  order: Order
+  onChange?: () => void
+  close: () => void
+}
+interface PropsAddresses {
+  customer: Customer
+  orderId: string
+  close: () => void
+  onChange?: () => void
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function useCustomerAddressOverlay(
+  order: Props['order'],
+  onChange?: Props['onChange']
+) {
+  const { Overlay, open, close } = useOverlay()
+  const customerId = order?.customer?.id ?? ''
+  // console.log('customer', customerId)
+  const { customer } = useCustomerDetails(customerId)
+  // console.log('customer', customer)
+  return {
+    close,
+    open,
+    Overlay: () => (
+      <Overlay>
+        <PageLayout
+          title='Assign Address'
+          navigationButton={{
+            onClick: () => {
+              close()
+            },
+            label: 'Cancel',
+            icon: 'x'
+          }}
+        >
+          <CustomerAddresses
+            customer={customer}
+            orderId={order?.id}
+            close={close}
+            onChange={onChange}
+          />
+        </PageLayout>
+      </Overlay>
+    )
+  }
+}
+
+const CustomerAddresses = withSkeletonTemplate<PropsAddresses>(
+  ({ customer, orderId, close, onChange }): JSX.Element | null => {
+    const { sdkClient } = useCoreSdkProvider()
+    const [apiError, setApiError] = useState<string>()
+    const handleSubmitAddress = async (
+      id: string | null,
+      billing: boolean
+    ): Promise<void> => {
+      if (id === null) {
+        close()
+      }
+      // if billing is true, update billing, if false, update shipping
+      billing
+        ? await sdkClient.orders
+            .update({
+              id: orderId,
+              billing_address: sdkClient.addresses.relationship(id)
+            })
+            .then(() => {
+              onChange?.()
+              close()
+            })
+            .catch((error) => {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              setApiError(error)
+            })
+        : await sdkClient.orders
+            .update({
+              id: orderId,
+              shipping_address: sdkClient.addresses.relationship(id)
+            })
+            .then(() => {
+              onChange?.()
+              close()
+            })
+            .catch((error) => {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              setApiError(error)
+            })
+    }
+
+    const addresses = customer.customer_addresses?.map(
+      (customerAddress, idx) =>
+        customerAddress?.address != null ? (
+          <ListItem key={idx}>
+            <div className='flex flex-col'>
+              {' '}
+              <Button
+                alignItems='center'
+                variant='secondary'
+                size='mini'
+                onClick={() => {
+                  void (async () => {
+                    await handleSubmitAddress(
+                      customerAddress?.address?.id ?? null,
+                      true
+                    )
+                  })()
+                }}
+                style={{ width: '12rem' }} // Inline style for custom width
+              >
+                <Icon name='bank' />
+                Use for Billing
+              </Button>
+              <Spacer bottom='10' />
+              <Button
+                alignItems='center'
+                variant='secondary'
+                size='mini'
+                onClick={() => {
+                  void (async () => {
+                    await handleSubmitAddress(
+                      customerAddress?.address?.id ?? null,
+                      false
+                    )
+                  })()
+                }}
+                style={{ width: '12rem' }} // Inline style for custom width
+              >
+                <Icon name='buildings' />
+                Use for Shipping
+              </Button>
+            </div>
+            <ResourceAddress
+              address={customerAddress?.address}
+              // editable={canUser('update', 'addresses')}
+              showBillingInfo
+            />
+          </ListItem>
+        ) : null
+    )
+
+    if (addresses?.length === 0)
+      return (
+        <>
+          <Alert status='warning'>
+            This customer does not have any addresses yet. Please go to the
+            customer app to create an address.
+          </Alert>
+        </>
+      )
+
+    return <Section title='Addresses'>{addresses}</Section>
+  }
+)


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When creating an order for a customer you currently need to type in a billing address and/or a shipping address. This is a big pain, as customers may have already existing addresses in the customer address book, which you can re-use. This pull request creates a button on the Address section on an order, which allows you to choose an Address from the customer address book to use a billing address or a shipping address.

Still do to: We were unsure how to actual handle a potential api error, with the apiError state. See the To Do in useCustomerAddressOverlay.tsx file

## How to test

<!-- Please include the steps to test your changes here -->
1. Create an order for a customer
2. Go to the address section, and choose the "Assign Address" button
3. Choose an address to use for Billing or Shipping and that's it.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->
- [X] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [X] Make sure to add/update documentation regarding your changes.
- [X] You are **NOT** deprecating/removing a feature.
