### PR TITLE
Add subscription trigger actions and edit form

### DIFF
--- a/apps/subscriptions/src/App.tsx
+++ b/apps/subscriptions/src/App.tsx
@@ -2,6 +2,7 @@ import { ErrorNotFound } from '#components/ErrorNotFound'
 import { appRoutes } from '#data/routes'
 import { Filters } from '#pages/Filters'
 import SubscriptionDetails from '#pages/SubscriptionDetails'
+import { SubscriptionEdit } from '#pages/SubscriptionEdit'
 import { SubscriptionOrders } from '#pages/SubscriptionOrders'
 import { SubscriptionsList } from '#pages/SubscriptionsList'
 import type { FC } from 'react'
@@ -29,6 +30,9 @@ export const App: FC<AppProps> = ({ routerBase }) => {
         </Route>
         <Route path={appRoutes.orders.path}>
           <SubscriptionOrders />
+        </Route>
+        <Route path={appRoutes.edit.path}>
+          <SubscriptionEdit />
         </Route>
         <Route>
           <ErrorNotFound />

--- a/apps/subscriptions/src/components/SubscriptionForm.tsx
+++ b/apps/subscriptions/src/components/SubscriptionForm.tsx
@@ -1,0 +1,89 @@
+import { getFrequencyLabelByValue } from '#data/frequencies'
+import { useSubscriptionModelsFrequencies } from '#hooks/useSubscriptionModelsFrequencies'
+import {
+  Button,
+  HookedForm,
+  HookedInputDate,
+  HookedInputSelect,
+  HookedValidationApiError,
+  Spacer
+} from '@commercelayer/app-elements'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm, type UseFormSetError } from 'react-hook-form'
+import { z } from 'zod'
+
+const subscriptionFormSchema = z.object({
+  id: z.string(),
+  frequency: z.string().nullable(),
+  nextRunAt: z.date()
+})
+
+export type SubscriptionFormValues = z.infer<typeof subscriptionFormSchema>
+
+interface Props {
+  defaultValues: SubscriptionFormValues
+  isSubmitting: boolean
+  onSubmit: (
+    formValues: SubscriptionFormValues,
+    setError: UseFormSetError<SubscriptionFormValues>
+  ) => void
+  apiError?: any
+}
+
+export function SubscriptionForm({
+  defaultValues,
+  onSubmit,
+  apiError,
+  isSubmitting
+}: Props): JSX.Element {
+  const methods = useForm({
+    defaultValues,
+    resolver: zodResolver(subscriptionFormSchema)
+  })
+
+  const frequencies = useSubscriptionModelsFrequencies()
+
+  return (
+    <HookedForm
+      {...methods}
+      onSubmit={(formValues) => {
+        onSubmit(formValues, methods.setError)
+      }}
+    >
+      <Spacer bottom='8'>
+        <HookedInputSelect
+          name='frequency'
+          label='Frequency'
+          initialValues={frequencies.map((f) => {
+            return {
+              label: getFrequencyLabelByValue(f),
+              value: f
+            }
+          })}
+          hint={{
+            text: `The frequency at which the subscription should run.`
+          }}
+        />
+      </Spacer>
+      <Spacer bottom='8'>
+        <HookedInputDate
+          name='nextRunAt'
+          label='Next run'
+          showTimeSelect
+          isClearable
+          hint={{
+            text: `The date and time of the subscription's next run.`
+          }}
+        />
+      </Spacer>
+      <Spacer top='14'>
+        <Button type='submit' disabled={isSubmitting} className='w-full'>
+          Update
+        </Button>
+        <Spacer top='2'>
+          <HookedValidationApiError apiError={apiError} />
+        </Spacer>
+      </Spacer>
+    </HookedForm>
+  )
+}

--- a/apps/subscriptions/src/components/SubscriptionSteps.tsx
+++ b/apps/subscriptions/src/components/SubscriptionSteps.tsx
@@ -88,11 +88,17 @@ export const SubscriptionSteps = withSkeletonTemplate<Props>(
             </Text>
           </Spacer>
           <Text>
-            {formatDate({
-              isoDate: subscription.next_run_at ?? '',
-              format: 'full',
-              timezone: user?.timezone
-            })}
+            {subscription.status !== 'cancelled' ? (
+              formatDate({
+                isoDate: subscription.next_run_at ?? '',
+                format: 'full',
+                timezone: user?.timezone
+              })
+            ) : (
+              <Text data-testid='empty-string' variant='disabled'>
+                &#8212;
+              </Text>
+            )}
           </Text>
         </div>
       </Stack>

--- a/apps/subscriptions/src/data/frequencies.ts
+++ b/apps/subscriptions/src/data/frequencies.ts
@@ -80,6 +80,17 @@ export const frequenciesForFilters = (): SelectableFrequency[] => {
   return frequencies
 }
 
+export const getFrequencyByValue = (
+  frequencyValue: string
+): SelectableFrequency => {
+  return (
+    frequenciesTranslations.find((f) => f.value === frequencyValue) ?? {
+      label: frequencyValue,
+      value: frequencyValue
+    }
+  )
+}
+
 /**
  * Extract, if available, a frequency label of a given value.
  * @param value - A given value to search for a label.

--- a/apps/subscriptions/src/data/routes.ts
+++ b/apps/subscriptions/src/data/routes.ts
@@ -12,5 +12,5 @@ export const appRoutes = {
   filters: createRoute('/filters/'),
   details: createRoute('/list/:subscriptionId/'),
   orders: createRoute('/list/:subscriptionId/orders/'),
-  editSubscription: createRoute('/list/:subscriptionId/edit/')
+  edit: createRoute('/list/:subscriptionId/edit/')
 }

--- a/apps/subscriptions/src/pages/SubscriptionEdit.tsx
+++ b/apps/subscriptions/src/pages/SubscriptionEdit.tsx
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+import {
+  SubscriptionForm,
+  type SubscriptionFormValues
+} from '#components/SubscriptionForm'
+import { appRoutes } from '#data/routes'
+import { useSubscriptionDetails } from '#hooks/useSubscriptionDetails'
+import {
+  Button,
+  EmptyState,
+  PageLayout,
+  SkeletonTemplate,
+  Spacer,
+  useCoreSdkProvider,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import {
+  type OrderSubscription,
+  type OrderSubscriptionUpdate
+} from '@commercelayer/sdk'
+import { useState } from 'react'
+import { Link, useLocation, useRoute } from 'wouter'
+
+export function SubscriptionEdit(): JSX.Element {
+  const { canUser } = useTokenProvider()
+  const { sdkClient } = useCoreSdkProvider()
+  const [, setLocation] = useLocation()
+  const [, params] = useRoute<{ subscriptionId: string }>(appRoutes.edit.path)
+  const subscriptionId = params?.subscriptionId ?? ''
+
+  const { subscription, isLoading, mutateSubscription } =
+    useSubscriptionDetails(subscriptionId)
+  const [apiError, setApiError] = useState<any>()
+  const [isSaving, setIsSaving] = useState(false)
+
+  const goBackUrl =
+    subscriptionId != null
+      ? appRoutes.details.makePath({ subscriptionId })
+      : appRoutes.list.makePath({})
+
+  if (!canUser('update', 'order_subscriptions')) {
+    return (
+      <PageLayout
+        title='Edit subscription'
+        navigationButton={{
+          onClick: () => {
+            setLocation(goBackUrl)
+          },
+          label: 'Cancel',
+          icon: 'x'
+        }}
+        scrollToTop
+        overlay
+      >
+        <EmptyState
+          title='Not found'
+          description='Subscription is invalid or you are not authorized to access this page.'
+          action={
+            <Link href={goBackUrl}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
+  }
+
+  return (
+    <PageLayout
+      title={
+        <SkeletonTemplate isLoading={isLoading}>
+          Edit subscription
+        </SkeletonTemplate>
+      }
+      navigationButton={{
+        onClick: () => {
+          setLocation(goBackUrl)
+        },
+        label: 'Cancel',
+        icon: 'x'
+      }}
+      scrollToTop
+      overlay
+    >
+      <Spacer bottom='14'>
+        {!isLoading && subscription != null ? (
+          <SubscriptionForm
+            defaultValues={adaptSubscriptionToFormValues(subscription)}
+            apiError={apiError}
+            isSubmitting={isSaving}
+            onSubmit={(formValues) => {
+              setIsSaving(true)
+              void sdkClient.order_subscriptions
+                .update(
+                  adaptFormValuesToSubscription(formValues) as OrderSubscription
+                )
+                .then(() => {
+                  void mutateSubscription().then(() => {
+                    setLocation(goBackUrl)
+                  })
+                })
+                .catch((error) => {
+                  setApiError(error)
+                  setIsSaving(false)
+                })
+            }}
+          />
+        ) : null}
+      </Spacer>
+    </PageLayout>
+  )
+}
+
+function adaptSubscriptionToFormValues(
+  subscription?: OrderSubscription
+): SubscriptionFormValues {
+  return {
+    id: subscription?.id ?? '',
+    frequency: subscription?.frequency ?? '',
+    nextRunAt: new Date(subscription?.next_run_at ?? '')
+  }
+}
+
+function adaptFormValuesToSubscription(
+  formValues: SubscriptionFormValues
+): OrderSubscriptionUpdate {
+  return {
+    id: formValues.id ?? '',
+    frequency: formValues.frequency,
+    next_run_at: formValues.nextRunAt.toJSON()
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added the top right toolbar in `detail` page with main trigger actions like `Deactivate` / `Activate` / `Cancel subscription` along with `Edit` button to go to the edit form.

<img width="600" alt="Screenshot 2024-11-12 alle 12 07 58" src="https://github.com/user-attachments/assets/84c59052-5f47-4dd1-902d-c15f9bda34d8" />
<img width="600" alt="Screenshot 2024-11-12 alle 12 08 40" src="https://github.com/user-attachments/assets/8ecedeb6-1ba8-4508-bfea-1decd3ff9c00">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
