### PR TITLE
Enable usage of colon symbol in `tags` app

### DIFF
--- a/apps/tags/src/components/TagForm.tsx
+++ b/apps/tags/src/components/TagForm.tsx
@@ -13,7 +13,7 @@ const tagFormSchema = z.object({
   name: z
     .string()
     .refine(
-      (value) => /^[a-zA-Z0-9]+(?:(-|_)[a-zA-Z0-9]+)*$/.test(value),
+      (value) => /^[a-zA-Z0-9]+(?:(-|_|:)[a-zA-Z0-9]+)*$/.test(value),
       'Name is invalid'
     )
 })


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enabled usage of colon symbol in `tags` app when setting the tag name. At the moment the `colon` (`:`) symbol is permitted only in the middle of the string as for the other permitted symbols (`-` and `_`).

<img width="600" alt="Screenshot 2024-11-18 alle 12 08 42" src="https://github.com/user-attachments/assets/3cacef5d-694b-43d7-a467-9eed410d1d11">
<img width="600" alt="Screenshot 2024-11-18 alle 12 10 35" src="https://github.com/user-attachments/assets/2baba3f1-f5f4-4f41-b170-aae867f6e4ad">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
