### PR TITLE
Price list rules with CodeEditor

### DIFF
--- a/apps/price_lists/src/components/PriceListForm.tsx
+++ b/apps/price_lists/src/components/PriceListForm.tsx
@@ -1,10 +1,10 @@
 import {
   Button,
+  HookedCodeEditor,
   HookedForm,
   HookedInput,
   HookedInputRadioGroup,
   HookedInputSelect,
-  HookedInputTextArea,
   HookedValidationApiError,
   Section,
   Spacer,
@@ -99,7 +99,13 @@ export function PriceListForm({
           </Spacer>
           {hasRuleEngine && (
             <Spacer top='6' bottom='4'>
-              <HookedInputTextArea name='rules' label='Rules' />
+              <HookedCodeEditor
+                name='rules'
+                label='Rules'
+                language='json'
+                jsonSchema='price-rules'
+                height='600px'
+              />
             </Spacer>
           )}
         </Section>


### PR DESCRIPTION
## What I did

I added the CodeEditor component to the price list rules:

<img width="668" alt="Screenshot 2024-12-04 alle 17 58 59" src="https://github.com/user-attachments/assets/c58484c5-16e2-405e-9c31-4ec741e0470f">
