### PR TITLE
Improve validation schema for input with type number in promotion forms

### DIFF
--- a/apps/promotions/src/data/formConverters/coupon.ts
+++ b/apps/promotions/src/data/formConverters/coupon.ts
@@ -4,14 +4,9 @@ import { z } from 'zod'
 export const couponForm = z.object({
   code: z.string().min(8).max(40),
   expires_at: z.date().nullish(),
-  usage_limit: z
-    .number()
-    .min(1)
-    .or(z.string().regex(/^[1-9][0-9]+$|^[1-9]$|^$/))
-    .nullish()
-    .transform((p) =>
-      p != null && p !== '' ? parseInt(p.toString()) : undefined
-    ),
+  usage_limit: z.preprocess((value) => {
+    return Number.isNaN(value) ? null : value
+  }, z.number().positive().nullish()),
   recipient_email: z.string().nullish(),
   customer_single_use: z.boolean().default(false)
 })

--- a/apps/promotions/src/data/promotions/configs/buy_x_pay_y_promotions.tsx
+++ b/apps/promotions/src/data/promotions/configs/buy_x_pay_y_promotions.tsx
@@ -13,6 +13,18 @@ import { PromotionSkuListSelector } from '../components/PromotionSkuListSelector
 import type { PromotionConfig } from '../config'
 import { genericPromotionOptions } from './promotions'
 
+const zodRequiredNumber = z.preprocess(
+  (value) => {
+    return Number.isNaN(value) ? null : value
+  },
+  z
+    .number({
+      message: 'Please enter a valid number',
+      invalid_type_error: 'Please enter a valid number'
+    })
+    .positive()
+)
+
 export default {
   buy_x_pay_y_promotions: {
     type: 'buy_x_pay_y_promotions',
@@ -24,8 +36,8 @@ export default {
     formType: genericPromotionOptions.merge(
       z.object({
         sku_list: z.string(),
-        x: z.number().min(1),
-        y: z.number().min(1),
+        x: zodRequiredNumber,
+        y: zodRequiredNumber,
         cheapest_free: z.boolean().default(false)
       })
     ),


### PR DESCRIPTION
Closes commercelayer/issues-app#287
Closes commercelayer/issues-app#290

## What I did

Improve validation schemas in `app-promotions` where input type is `number`.
It now accepts nullish values and error messages are more user friendly.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
