### PR TITLE
Replace static coupon table with `ResourceList` in app-promotions

### DIFF
--- a/apps/promotions/src/pages/CouponListPage.tsx
+++ b/apps/promotions/src/pages/CouponListPage.tsx
@@ -1,4 +1,4 @@
-import { CouponTable } from '#components/CouponTable'
+import { CouponRow } from '#components/CouponTable'
 import type { PageProps } from '#components/Routes'
 import { appRoutes } from '#data/routes'
 import {
@@ -18,7 +18,7 @@ function Page(props: PageProps<typeof appRoutes.couponList>): JSX.Element {
   const [, setLocation] = useLocation()
   const [searchValue, setSearchValue] = useState<string>()
 
-  const { list, isLoading, removeItem } = useResourceList({
+  const { list, ResourceList } = useResourceList({
     type: 'coupons',
     query: {
       filters: {
@@ -77,15 +77,29 @@ function Page(props: PageProps<typeof appRoutes.couponList>): JSX.Element {
       </Spacer>
 
       <Spacer top='10'>
-        <CouponTable
-          isLoading={isLoading}
-          boxed
-          promotionId={props.params.promotionId}
-          coupons={list ?? []}
-          onDelete={(couponId) => {
-            removeItem(couponId)
+        <div
+          style={{
+            borderWidth: '1px',
+            borderBottom: 0
           }}
-        />
+        >
+          <ResourceList
+            variant='table'
+            headings={[
+              { label: 'Code' },
+              { label: 'Used' },
+              { label: 'Expiry' },
+              { label: '' }
+            ]}
+            ItemTemplate={(p) => (
+              <CouponRow
+                {...p}
+                deleteRule={list?.length === 1}
+                promotionId={props.params.promotionId}
+              />
+            )}
+          />
+        </div>
       </Spacer>
     </PageLayout>
   )


### PR DESCRIPTION
Closes commercelayer/issues-app#291

## What I did

I have replaced the coupon table with the `ResourceList` component having variant `table`.
In this way we can have infinite scrolling in the view all coupons page (instead of showing only the first 10 items).



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
