### PR TITLE
Hide SKU list selection when editing a bundle

### DIFF
--- a/apps/bundles/src/components/BundleForm.tsx
+++ b/apps/bundles/src/components/BundleForm.tsx
@@ -179,31 +179,32 @@ export function BundleForm({
             </Grid>
           </Spacer>
         </Section>
-
-        <Section title='Bundle items'>
-          <Spacer top='4' bottom='4'>
-            <Text variant='info'>
-              Select the manual SKU list containing the bundle items.
-            </Text>
-          </Spacer>
-          <Spacer top='4' bottom='12'>
-            {!isLoadingSkuLists && <SkuListsSelect options={skuLists} />}
-            {bundleFormWatchedSkuList != null && (
-              <Spacer top='4' bottom='2'>
-                <Card gap='none'>
-                  {skuListItems != null
-                    ? skuListItems.map((item) => (
-                        <ListItemSkuListItem
-                          key={item.sku_code}
-                          resource={item}
-                        />
-                      ))
-                    : null}
-                </Card>
-              </Spacer>
-            )}
-          </Spacer>
-        </Section>
+        {defaultValues?.id == null && (
+          <Section title='Bundle items'>
+            <Spacer top='4' bottom='4'>
+              <Text variant='info'>
+                Select the manual SKU list containing the bundle items.
+              </Text>
+            </Spacer>
+            <Spacer top='4' bottom='12'>
+              {!isLoadingSkuLists && <SkuListsSelect options={skuLists} />}
+              {bundleFormWatchedSkuList != null && (
+                <Spacer top='4' bottom='2'>
+                  <Card gap='none'>
+                    {skuListItems != null
+                      ? skuListItems.map((item) => (
+                          <ListItemSkuListItem
+                            key={item.sku_code}
+                            resource={item}
+                          />
+                        ))
+                      : null}
+                  </Card>
+                </Spacer>
+              )}
+            </Spacer>
+          </Section>
+        )}
 
         <Section title='Selling info'>
           <Spacer top='6'>


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/282

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Hide SKU list selection when editing a bundle to avoid unwanted behavior. The SKU list can be set only during bundle creation.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
