### PR TITLE
Set correct order to mount `I18NProvider` in `app-shipments`

### DIFF
--- a/apps/shipments/src/main.tsx
+++ b/apps/shipments/src/main.tsx
@@ -22,20 +22,20 @@ const Main: React.FC<ClAppProps> = (props) => (
           revalidateOnFocus: false
         }}
       >
-        <I18NProvider>
-          <TokenProvider
-            kind='shipments'
-            appSlug='shipments'
-            devMode={isDev}
-            loadingElement={<div />}
-            {...props}
-          >
+        <TokenProvider
+          kind='shipments'
+          appSlug='shipments'
+          devMode={isDev}
+          loadingElement={<div />}
+          {...props}
+        >
+          <I18NProvider>
             <CoreSdkProvider>
               <MetaTags />
               <App routerBase={props?.routerBase} />
             </CoreSdkProvider>
-          </TokenProvider>
-        </I18NProvider>
+          </I18NProvider>
+        </TokenProvider>
       </SWRConfig>
     </ErrorBoundary>
   </StrictMode>


### PR DESCRIPTION
## What I did
This pull request includes a change to the `apps/shipments/src/main.tsx` file to rearrange the order of the `I18NProvider` and `TokenProvider` components. 

Codebase simplification:

* [`apps/shipments/src/main.tsx`](diffhunk://#diff-ba526adf0cce22fce8bb9380149ee42d4188274df9745ac6f07cc6ebdbe687dfL25-R38): Moved the `I18NProvider` component inside the `TokenProvider` component to ensure proper context wrapping and potentially resolve issues related to internationalization and token management.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
