### PR TITLE
Show correct sales channel used in an already generated link

### DIFF
--- a/apps/orders/src/hooks/useGetCheckoutLink.tsx
+++ b/apps/orders/src/hooks/useGetCheckoutLink.tsx
@@ -4,15 +4,21 @@ import { addMonths } from 'date-fns/addMonths'
 import { useEffect, useState } from 'react'
 
 interface Props {
+  /** The order id. */
   orderId: Order['id']
+  /**
+   * The client id of a sales channel API credential used to create the link the first time.
+   * If missing it won't be possible to generate a new link the first time.
+   **/
   clientId?: string
+  /** The given scope. */
   scope?: string
 }
 
 /**
  * Get or create a checkout link related to a given order.
  * @param orderId - The order id.
- * @param clientId - The client id of a sales channel API credential.
+ * @param clientId - The client id of a sales channel API credential used to create the link the first time.
  * @param scope - The given scope.
  * @returns a list of resolved `Links`.
  */

--- a/apps/orders/src/pages/LinkDetails.tsx
+++ b/apps/orders/src/pages/LinkDetails.tsx
@@ -42,12 +42,6 @@ function LinkDetails(
   const [, setLocation] = useLocation()
   const orderId = props.params?.orderId ?? ''
 
-  const linkSalesChannel = useMemo(() => {
-    if (extras?.salesChannels != null && extras?.salesChannels.length > 0) {
-      return extras.salesChannels[0]
-    }
-  }, [extras?.salesChannels])
-
   const { order } = useOrderDetails(orderId)
 
   const linkScope = useMemo(() => {
@@ -58,9 +52,18 @@ function LinkDetails(
 
   const { link, isLoading } = useGetCheckoutLink({
     orderId,
-    clientId: linkSalesChannel?.client_id,
+    clientId: extras?.salesChannels?.[0]?.client_id,
     scope: linkScope
   })
+
+  const linkSalesChannel = useMemo(() => {
+    return (
+      extras?.salesChannels?.find((sc) => sc.client_id === link?.client_id) ?? {
+        name: 'Sales channel',
+        client_id: link?.client_id
+      }
+    )
+  }, [extras?.salesChannels, link?.client_id])
 
   const pageTitle = t('common.links.checkout_link_status', {
     status: link?.status


### PR DESCRIPTION
## What I did

I've fixed an issue related to a wrong visualization of the sales channel used for the generated link.



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
