### PR TITLE
Allow to override support email recipient

### DIFF
--- a/apps/customers/src/hooks/useCustomerDeleteOverlay.tsx
+++ b/apps/customers/src/hooks/useCustomerDeleteOverlay.tsx
@@ -11,6 +11,7 @@ import {
   useTranslation,
   type PageLayoutProps
 } from '@commercelayer/app-elements'
+import isEmpty from 'lodash/isEmpty'
 import { useMemo, useState } from 'react'
 import { useLocation } from 'wouter'
 
@@ -33,8 +34,13 @@ export function useCustomerDeleteOverlay(customerId: string): OverlayHook {
     settings: { isFiltered: false }
   })
 
+  const recipientOverride = sessionStorage.getItem(
+    `customers:${organization?.slug}:supportEmail`
+  )
   const customerDeletionMail = {
-    recipient: 'support@commercelayer.io',
+    recipient: isEmpty(recipientOverride)
+      ? 'support@commercelayer.io'
+      : recipientOverride,
     subject: `Anonymize customer ${customer.email}`,
     body: `Anonymization request for customer ${customer.email} of organization ${organization?.name}`
   }


### PR DESCRIPTION
## What I did

In case the following key is found in session storage `customers:${organization?.slug}:supportEmail`, its content will be used as recipient for the useCustomerDeleteOverlay message

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
