### PR TITLE
Drop usage of shouldRender method

### DIFF
--- a/apps/customers/src/components/CustomerForm.tsx
+++ b/apps/customers/src/components/CustomerForm.tsx
@@ -7,7 +7,6 @@ import {
   Spacer,
   Text,
   useCoreSdkProvider,
-  useTokenProvider,
   useTranslation
 } from '@commercelayer/app-elements'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -43,7 +42,6 @@ export function CustomerForm({
   isSubmitting
 }: Props): JSX.Element {
   const { t } = useTranslation()
-  const { shouldRender } = useTokenProvider()
   const methods = useForm({
     defaultValues,
     resolver: zodResolver(customerFormSchema)
@@ -76,7 +74,7 @@ export function CustomerForm({
         />
       </Spacer>
 
-      {!isLoadingCustomerGroups && shouldRender('customer_groups') && (
+      {!isLoadingCustomerGroups && (
         <Spacer bottom='8'>
           <Select options={customerGroups} />
         </Spacer>

--- a/apps/customers/src/pages/CustomerDetails.tsx
+++ b/apps/customers/src/pages/CustomerDetails.tsx
@@ -29,7 +29,6 @@ export function CustomerDetails(): JSX.Element {
   const {
     settings: { mode },
     user,
-    shouldRender,
     canUser
   } = useTokenProvider()
   const [, setLocation] = useLocation()
@@ -129,43 +128,39 @@ export function CustomerDetails(): JSX.Element {
             <Spacer top='14'>
               <CustomerAddresses customer={customer} />
             </Spacer>
-            {shouldRender('details') && (
-              <Spacer top='14'>
-                <ResourceDetails
-                  resource={customer}
-                  onUpdated={async () => {
-                    void mutateCustomer()
-                  }}
-                />
-              </Spacer>
-            )}
+
+            <Spacer top='14'>
+              <ResourceDetails
+                resource={customer}
+                onUpdated={async () => {
+                  void mutateCustomer()
+                }}
+              />
+            </Spacer>
+
             {!isMockedId(customer.id) && (
               <>
-                {shouldRender('tags') && (
-                  <Spacer top='14'>
-                    <ResourceTags
-                      resourceType='customers'
-                      resourceId={customer.id}
-                      overlay={{ title: pageTitle }}
-                      onTagClick={(tagId) => {
-                        setLocation(
-                          appRoutes.list.makePath(`tags_id_in=${tagId}`)
-                        )
-                      }}
-                    />
-                  </Spacer>
-                )}
-                {shouldRender('metadata') && (
-                  <Spacer top='14'>
-                    <ResourceMetadata
-                      resourceType='customers'
-                      resourceId={customer.id}
-                      overlay={{
-                        title: pageTitle
-                      }}
-                    />
-                  </Spacer>
-                )}
+                <Spacer top='14'>
+                  <ResourceTags
+                    resourceType='customers'
+                    resourceId={customer.id}
+                    overlay={{ title: pageTitle }}
+                    onTagClick={(tagId) => {
+                      setLocation(
+                        appRoutes.list.makePath(`tags_id_in=${tagId}`)
+                      )
+                    }}
+                  />
+                </Spacer>
+                <Spacer top='14'>
+                  <ResourceMetadata
+                    resourceType='customers'
+                    resourceId={customer.id}
+                    overlay={{
+                      title: pageTitle
+                    }}
+                  />
+                </Spacer>
               </>
             )}
             <Spacer top='14'>

--- a/apps/orders/src/components/NewOrder/EditOrderStep.tsx
+++ b/apps/orders/src/components/NewOrder/EditOrderStep.tsx
@@ -15,7 +15,6 @@ import {
   Spacer,
   t,
   useCoreSdkProvider,
-  useTokenProvider,
   useTranslation,
   type PageProps
 } from '@commercelayer/app-elements'
@@ -34,7 +33,6 @@ export const EditOrderStep: React.FC<
   }
 > = ({ overlay, orderId }) => {
   const [, setLocation] = useLocation()
-  const { shouldRender } = useTokenProvider()
   const [apiError, setApiError] = useState<any>()
   const { sdkClient } = useCoreSdkProvider()
   const { t } = useTranslation()
@@ -89,7 +87,7 @@ export const EditOrderStep: React.FC<
         <span>
           <SkeletonTemplate isLoading={isLoading}>
             {t('common.new')} {t('resources.orders.name').toLowerCase()}{' '}
-            {shouldRender('markets') ? order.market?.name : ''}
+            {order.market?.name}
           </SkeletonTemplate>
         </span>
       }

--- a/apps/orders/src/pages/Home.tsx
+++ b/apps/orders/src/pages/Home.tsx
@@ -12,7 +12,6 @@ import {
   Text,
   useCoreSdkProvider,
   useResourceFilters,
-  useTokenProvider,
   useTranslation
 } from '@commercelayer/app-elements'
 import { Link, useLocation } from 'wouter'
@@ -22,7 +21,6 @@ import { useListCounters } from '../metricsApi/useListCounters'
 function Home(): JSX.Element {
   const [, setLocation] = useLocation()
   const { t } = useTranslation()
-  const { shouldRender } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const search = useSearch()
   const { data: counters, isLoading: isLoadingCounters } = useListCounters()
@@ -35,46 +33,44 @@ function Home(): JSX.Element {
     <HomePageLayout
       title={t('resources.orders.name_other')}
       toolbar={{
-        buttons: shouldRender('create')
-          ? [
-              {
-                icon: 'plus',
-                label: `${t('common.new')} ${t('resources.orders.name').toLowerCase()}`,
-                size: 'small',
-                onClick: () => {
-                  void sdkClient.markets
-                    .list({
-                      fields: ['id'],
-                      filters: {
-                        disabled_at_null: true
-                      },
-                      pageSize: 1
-                    })
-                    .then((markets) => {
-                      if (markets.meta.recordCount > 1) {
-                        setLocation(appRoutes.new.makePath({}))
-                      } else {
-                        const [resource] = markets
-                        if (resource != null) {
-                          void sdkClient.orders
-                            .create({
-                              market: {
-                                type: 'markets',
-                                id: resource.id
-                              }
-                            })
-                            .then((order) => {
-                              setLocation(
-                                appRoutes.new.makePath({ orderId: order.id })
-                              )
-                            })
-                        }
-                      }
-                    })
-                }
-              }
-            ]
-          : undefined
+        buttons: [
+          {
+            icon: 'plus',
+            label: `${t('common.new')} ${t('resources.orders.name').toLowerCase()}`,
+            size: 'small',
+            onClick: () => {
+              void sdkClient.markets
+                .list({
+                  fields: ['id'],
+                  filters: {
+                    disabled_at_null: true
+                  },
+                  pageSize: 1
+                })
+                .then((markets) => {
+                  if (markets.meta.recordCount > 1) {
+                    setLocation(appRoutes.new.makePath({}))
+                  } else {
+                    const [resource] = markets
+                    if (resource != null) {
+                      void sdkClient.orders
+                        .create({
+                          market: {
+                            type: 'markets',
+                            id: resource.id
+                          }
+                        })
+                        .then((order) => {
+                          setLocation(
+                            appRoutes.new.makePath({ orderId: order.id })
+                          )
+                        })
+                    }
+                  }
+                })
+            }
+          }
+        ]
       }}
     >
       <SearchWithNav

--- a/apps/orders/src/pages/OrderDetails.tsx
+++ b/apps/orders/src/pages/OrderDetails.tsx
@@ -34,7 +34,6 @@ import { useLocation, useRoute } from 'wouter'
 function OrderDetails(): JSX.Element {
   const {
     canUser,
-    shouldRender,
     settings: { mode, extras },
     user
   } = useTokenProvider()
@@ -188,43 +187,37 @@ function OrderDetails(): JSX.Element {
               <OrderReturns returns={returns} />
             </Spacer>
           )}
-          {shouldRender('details') && (
-            <Spacer top='14'>
-              <ResourceDetails
-                resource={order}
-                onUpdated={async () => {
-                  void mutateOrder()
-                }}
-              />
-            </Spacer>
-          )}
+          <Spacer top='14'>
+            <ResourceDetails
+              resource={order}
+              onUpdated={async () => {
+                void mutateOrder()
+              }}
+            />
+          </Spacer>
           {!isMockedId(order.id) && (
             <>
-              {shouldRender('tags') && (
-                <Spacer top='14'>
-                  <ResourceTags
-                    resourceType='orders'
-                    resourceId={order.id}
-                    overlay={{ title: pageTitle }}
-                    onTagClick={(tagId) => {
-                      setLocation(
-                        appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
-                      )
-                    }}
-                  />
-                </Spacer>
-              )}
-              {shouldRender('metadata') && (
-                <Spacer top='14'>
-                  <ResourceMetadata
-                    resourceType='orders'
-                    resourceId={order.id}
-                    overlay={{
-                      title: pageTitle
-                    }}
-                  />
-                </Spacer>
-              )}
+              <Spacer top='14'>
+                <ResourceTags
+                  resourceType='orders'
+                  resourceId={order.id}
+                  overlay={{ title: pageTitle }}
+                  onTagClick={(tagId) => {
+                    setLocation(
+                      appRoutes.list.makePath({}, `tags_id_in=${tagId}`)
+                    )
+                  }}
+                />
+              </Spacer>
+              <Spacer top='14'>
+                <ResourceMetadata
+                  resourceType='orders'
+                  resourceId={order.id}
+                  overlay={{
+                    title: pageTitle
+                  }}
+                />
+              </Spacer>
             </>
           )}
           {!['draft'].includes(order.status) && (

--- a/apps/orders/src/pages/OrderNew.tsx
+++ b/apps/orders/src/pages/OrderNew.tsx
@@ -1,17 +1,11 @@
 import { EditOrderStep } from '#components/NewOrder/EditOrderStep'
 import { SelectMarketStep } from '#components/NewOrder/SelectMarketStep'
 import { type appRoutes } from '#data/routes'
-import { useTokenProvider, type PageProps } from '@commercelayer/app-elements'
+import { type PageProps } from '@commercelayer/app-elements'
 
 function NewOrderPage(
   props: PageProps<typeof appRoutes.new>
 ): JSX.Element | null {
-  const { shouldRender } = useTokenProvider()
-
-  if (!shouldRender('create')) {
-    return null
-  }
-
   if (props.params.orderId != null) {
     return (
       <EditOrderStep overlay={props.overlay} orderId={props.params.orderId} />

--- a/apps/returns/src/pages/ReturnDetails.tsx
+++ b/apps/returns/src/pages/ReturnDetails.tsx
@@ -25,7 +25,6 @@ import { Link, useLocation, useRoute } from 'wouter'
 function ReturnDetails(): JSX.Element {
   const {
     canUser,
-    shouldRender,
     settings: { mode }
   } = useTokenProvider()
   const [, setLocation] = useLocation()
@@ -95,40 +94,34 @@ function ReturnDetails(): JSX.Element {
           <Spacer top='14'>
             <ReturnAddresses returnObj={returnObj} />
           </Spacer>
-          {shouldRender('details') && (
-            <Spacer top='14'>
-              <ResourceDetails
-                resource={returnObj}
-                onUpdated={async () => {
-                  void mutateReturn()
-                }}
-              />
-            </Spacer>
-          )}
+          <Spacer top='14'>
+            <ResourceDetails
+              resource={returnObj}
+              onUpdated={async () => {
+                void mutateReturn()
+              }}
+            />
+          </Spacer>
           {!isMockedId(returnObj.id) && (
             <>
-              {shouldRender('tags') && (
-                <Spacer top='14'>
-                  <ResourceTags
-                    resourceType='returns'
-                    resourceId={returnObj.id}
-                    overlay={{
-                      title: pageTitle
-                    }}
-                  />
-                </Spacer>
-              )}
-              {shouldRender('metadata') && (
-                <Spacer top='14'>
-                  <ResourceMetadata
-                    resourceType='returns'
-                    resourceId={returnObj.id}
-                    overlay={{
-                      title: pageTitle
-                    }}
-                  />
-                </Spacer>
-              )}
+              <Spacer top='14'>
+                <ResourceTags
+                  resourceType='returns'
+                  resourceId={returnObj.id}
+                  overlay={{
+                    title: pageTitle
+                  }}
+                />
+              </Spacer>
+              <Spacer top='14'>
+                <ResourceMetadata
+                  resourceType='returns'
+                  resourceId={returnObj.id}
+                  overlay={{
+                    title: pageTitle
+                  }}
+                />
+              </Spacer>
             </>
           )}
           <Spacer top='14'>

--- a/apps/shipments/src/pages/ShipmentDetails.tsx
+++ b/apps/shipments/src/pages/ShipmentDetails.tsx
@@ -29,7 +29,6 @@ import { useRoute } from 'wouter'
 function ShipmentDetails(): JSX.Element {
   const {
     canUser,
-    shouldRender,
     settings: { mode },
     user
   } = useTokenProvider()
@@ -137,40 +136,34 @@ function ShipmentDetails(): JSX.Element {
           <Spacer top='14'>
             <ShipmentInfo shipment={shipment} />
           </Spacer>
-          {shouldRender('details') && (
-            <Spacer top='14'>
-              <ResourceDetails
-                resource={shipment}
-                onUpdated={async () => {
-                  void mutateShipment()
-                }}
-              />
-            </Spacer>
-          )}
+          <Spacer top='14'>
+            <ResourceDetails
+              resource={shipment}
+              onUpdated={async () => {
+                void mutateShipment()
+              }}
+            />
+          </Spacer>
           {!isMockedId(shipment.id) && (
             <>
-              {shouldRender('tags') && (
-                <Spacer top='14'>
-                  <ResourceTags
-                    resourceType='shipments'
-                    resourceId={shipment.id}
-                    overlay={{
-                      title: pageTitle
-                    }}
-                  />
-                </Spacer>
-              )}
-              {shouldRender('metadata') && (
-                <Spacer top='14'>
-                  <ResourceMetadata
-                    resourceType='shipments'
-                    resourceId={shipment.id}
-                    overlay={{
-                      title: pageTitle
-                    }}
-                  />
-                </Spacer>
-              )}
+              <Spacer top='14'>
+                <ResourceTags
+                  resourceType='shipments'
+                  resourceId={shipment.id}
+                  overlay={{
+                    title: pageTitle
+                  }}
+                />
+              </Spacer>
+              <Spacer top='14'>
+                <ResourceMetadata
+                  resourceType='shipments'
+                  resourceId={shipment.id}
+                  overlay={{
+                    title: pageTitle
+                  }}
+                />
+              </Spacer>
             </>
           )}
           <Spacer top='14'>


### PR DESCRIPTION
## What I did

Since `shouldRender` method won't be exposed anymore from TokenProvider, we can drop its usage from the apps

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
