### PR TITLE
Fix validation of SKUList rule for minimum qty input

### DIFF
--- a/apps/promotions/src/data/ruleBuilder/form/validator.tsx
+++ b/apps/promotions/src/data/ruleBuilder/form/validator.tsx
@@ -83,22 +83,15 @@ export const ruleBuilderFormValidator = z
           .or(z.number())
           .nullable(),
         all_skus: z.enum(['all', 'any', 'number']),
-        min_quantity: z
-          .string()
-          .nullable()
-          .default(null)
-          .transform((minQuantity) => {
-            if (isNaN(parseInt(minQuantity ?? ''))) {
-              return null
-            }
-
-            return minQuantity
-          })
+        min_quantity: z.preprocess((value) => {
+          return Number.isNaN(value) ? null : value
+        }, z.number().positive().nullish())
       })
       .superRefine((data, ctx) => {
         if (
           data.all_skus === 'number' &&
-          isNaN(parseInt(data.min_quantity ?? ''))
+          (data.min_quantity == null ||
+            (data.min_quantity != null && data.min_quantity === 0))
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/340

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed validation of SKUList rule for minimum qty input in Promotions app.
Actually was evaluating the value of the input as string instead of number.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
