### PR TITLE
Fix names of coupon code length flags

### DIFF
--- a/apps/promotions/src/components/CouponForm.tsx
+++ b/apps/promotions/src/components/CouponForm.tsx
@@ -44,13 +44,11 @@ export function CouponForm({
   const { sdkClient } = useCoreSdkProvider()
   const { data: organization } = useCoreApi('organization', 'retrieve', [])
   const minCodeLength = useMemo(
-    // @ts-expect-error types are not up to date
-    () => organization?.coupon_code_min_length ?? 8,
+    () => organization?.coupons_min_code_length ?? 8,
     [organization]
   )
   const maxCodeLength = useMemo(
-    // @ts-expect-error types are not up to date
-    () => organization?.coupon_code_max_length ?? 40,
+    () => organization?.coupons_max_code_length ?? 40,
     [organization]
   )
 

--- a/apps/promotions/src/components/CouponForm.tsx
+++ b/apps/promotions/src/components/CouponForm.tsx
@@ -24,7 +24,7 @@ import { type z } from 'zod'
 interface Props {
   promotionId: string
   couponId?: string
-  defaultValues?: Partial<z.infer<typeof couponForm>>
+  defaultValues?: Partial<z.infer<ReturnType<typeof couponForm>>>
 }
 
 export function CouponForm({
@@ -36,10 +36,6 @@ export function CouponForm({
   const [apiError, setApiError] = useState<any>()
   const { promotion } = usePromotion(promotionId)
   const { mutateCoupon } = useCoupon(couponId)
-  const methods = useForm<z.infer<typeof couponForm>>({
-    defaultValues,
-    resolver: zodResolver(couponForm)
-  })
 
   const { sdkClient } = useCoreSdkProvider()
   const { data: organization } = useCoreApi('organization', 'retrieve', [])
@@ -51,6 +47,10 @@ export function CouponForm({
     () => organization?.coupons_max_code_length ?? 40,
     [organization]
   )
+  const methods = useForm<z.infer<ReturnType<typeof couponForm>>>({
+    defaultValues,
+    resolver: zodResolver(couponForm(minCodeLength, maxCodeLength))
+  })
 
   return (
     <HookedForm

--- a/apps/promotions/src/data/formConverters/coupon.ts
+++ b/apps/promotions/src/data/formConverters/coupon.ts
@@ -1,15 +1,18 @@
 import type { Coupon, CouponCreate, CouponUpdate } from '@commercelayer/sdk'
 import { z } from 'zod'
 
-export const couponForm = z.object({
-  code: z.string().min(8).max(40),
-  expires_at: z.date().nullish(),
-  usage_limit: z.preprocess((value) => {
-    return Number.isNaN(value) ? null : value
-  }, z.number().positive().nullish()),
-  recipient_email: z.string().nullish(),
-  customer_single_use: z.boolean().default(false)
-})
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const couponForm = (codeMin: number, codeMax: number) => {
+  return z.object({
+    code: z.string().min(codeMin).max(codeMax),
+    expires_at: z.date().nullish(),
+    usage_limit: z.preprocess((value) => {
+      return Number.isNaN(value) ? null : value
+    }, z.number().positive().nullish()),
+    recipient_email: z.string().nullish(),
+    customer_single_use: z.boolean().default(false)
+  })
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function couponToFormValues(coupon?: Coupon) {
@@ -29,7 +32,9 @@ export function couponToFormValues(coupon?: Coupon) {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function formValuesToCoupon(formValues: z.infer<typeof couponForm>) {
+export function formValuesToCoupon(
+  formValues: z.infer<ReturnType<typeof couponForm>>
+) {
   return {
     ...formValues,
     expires_at:


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fix copy error in names of coupon code length flags.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
