### PR TITLE
Add optional stock location selection in links scope configuration

### DIFF
--- a/packages/common/src/pages/LinkEditPage.tsx
+++ b/packages/common/src/pages/LinkEditPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '@commercelayer/app-elements'
 
 import type { Link, LinkUpdate, Sku, SkuList } from '@commercelayer/sdk'
+import isEmpty from 'lodash-es/isEmpty'
 import { useState } from 'react'
 import { useLocation } from 'wouter'
 import { LinkForm, type LinkFormValues } from '../components/LinkForm'
@@ -112,11 +113,17 @@ export const LinkEditPage = ({
 }
 
 function adaptLinkToFormValues(link?: Link): LinkFormValues {
+  let [market, stockLocation] = link?.scope.split(' ') ?? []
+  market = market != null ? market?.replace('market:id:', '') : ''
+  stockLocation =
+    stockLocation != null ? stockLocation.replace('stock_location:id:', '') : ''
+
   return {
     id: link?.id,
     name: link?.name ?? '',
     clientId: link?.client_id ?? '',
-    market: link?.scope.replace('market:id:', '') ?? '',
+    market,
+    stockLocation,
     startsAt: new Date(link?.starts_at ?? ''),
     expiresAt: new Date(link?.expires_at ?? '')
   }
@@ -131,7 +138,7 @@ function adaptFormValuesToLink(
     id: formValues.id ?? '',
     name: formValues.name,
     client_id: formValues.clientId,
-    scope: `market:id:${formValues.market}`,
+    scope: `market:id:${formValues.market}${!isEmpty(formValues.stockLocation) ? ` stock_location:id:${formValues.stockLocation}` : ''}`,
     starts_at: formValues.startsAt.toJSON(),
     expires_at: formValues.expiresAt.toJSON(),
     item: {

--- a/packages/common/src/pages/LinkNewPage.tsx
+++ b/packages/common/src/pages/LinkNewPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@commercelayer/app-elements'
 
 import type { LinkCreate, Sku, SkuList } from '@commercelayer/sdk'
+import isEmpty from 'lodash-es/isEmpty'
 import { useState } from 'react'
 import { Link, useLocation } from 'wouter'
 import { LinkForm, type LinkFormValues } from '../components/LinkForm'
@@ -109,7 +110,7 @@ function adaptFormValuesToLink(
   return {
     name: formValues.name,
     client_id: formValues.clientId,
-    scope: `market:id:${formValues.market}`,
+    scope: `market:id:${formValues.market}${!isEmpty(formValues.stockLocation) ? ` stock_location:id:${formValues.stockLocation}` : ''}`,
     starts_at: formValues.startsAt.toJSON(),
     expires_at: formValues.expiresAt.toJSON(),
     item: {


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/343

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added optional stock location selection in links scope configuration to eventually restrict a link to a particular stock location of a selected market (still required).
The stock location select is at first hidden and will popup as soon as a market is selected with at least `2` or more stock locations with a default empty selection (`All stock locations`).

<img width="500" alt="Screenshot 2025-03-21 alle 09 19 38" src="https://github.com/user-attachments/assets/3ca05b3e-41e7-4e73-8c6e-4317a86e6b2f" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
