### PR TITLE
Handle async capture in order details

### DIFF
--- a/apps/orders/src/components/OrderSummary/hooks/useActionButtons.tsx
+++ b/apps/orders/src/components/OrderSummary/hooks/useActionButtons.tsx
@@ -1,8 +1,9 @@
 import { useCancelOverlay } from '#hooks/useCancelOverlay'
 import { useTriggerAttribute } from '#hooks/useTriggerAttribute'
 import {
-  useTranslation,
-  type ActionButtonsProps
+  type ActionButtonsProps,
+  orderTransactionIsAnAsyncCapture,
+  useTranslation
 } from '@commercelayer/app-elements'
 import type { Order } from '@commercelayer/sdk'
 import { useMemo } from 'react'
@@ -48,6 +49,18 @@ export const useActionButtons = ({ order }: { order: Order }) => {
         > => !['_archive', '_unarchive', '_refund'].includes(triggerAttribute)
       )
       .map((triggerAttribute) => {
+        if (
+          triggerAttribute === '_capture' &&
+          (order?.transactions ?? []).some(orderTransactionIsAnAsyncCapture)
+        ) {
+          // Capture has already been triggered and is waiting for success
+          return {
+            label: t('apps.orders.details.waiting_for_successful_capture'),
+            variant: 'primary',
+            disabled: true,
+            onClick: () => {}
+          }
+        }
         return {
           label: getTriggerAttributeName(triggerAttribute),
           variant:

--- a/apps/orders/src/hooks/useOrderDetails.tsx
+++ b/apps/orders/src/hooks/useOrderDetails.tsx
@@ -1,5 +1,8 @@
 import { isMockedId, makeOrder } from '#mocks'
-import { useCoreApi } from '@commercelayer/app-elements'
+import {
+  orderTransactionIsAnAsyncCapture,
+  useCoreApi
+} from '@commercelayer/app-elements'
 import isEmpty from 'lodash-es/isEmpty'
 
 export const orderIncludeAttribute = [
@@ -48,7 +51,14 @@ export function useOrderDetails(id: string) {
         ]
       : null,
     {
-      fallbackData: makeOrder()
+      fallbackData: makeOrder(),
+      refreshInterval: (order) => {
+        return (order?.transactions ?? []).some(
+          orderTransactionIsAnAsyncCapture
+        )
+          ? 5000
+          : 0
+      }
     }
   )
 


### PR DESCRIPTION
## What I did

This PR introduces logic to detect if a capture is asynchronous and its associated job is still pending.
When an async capture is detected, the "Capture" button is shown as disabled, and polling is activated on the order to wait for the capture to complete.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
