### PR TITLE
Enable `generic` apps

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.36.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.36.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.36.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.36.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/my_sample_app/.env
+++ b/apps/my_sample_app/.env
@@ -1,0 +1,4 @@
+# Base router path for the project
+PUBLIC_PROJECT_PATH=
+# When set it defines the slug for the self hosted version of the project
+PUBLIC_SELF_HOSTED_SLUG=

--- a/apps/my_sample_app/.eslintrc.cjs
+++ b/apps/my_sample_app/.eslintrc.cjs
@@ -1,0 +1,15 @@
+const path = require('path')
+
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  extends: ['@commercelayer/eslint-config-ts-react'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: path.resolve(__dirname, 'tsconfig.json'),
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 12,
+    sourceType: 'module'
+  }
+}

--- a/apps/my_sample_app/.gitignore
+++ b/apps/my_sample_app/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/apps/my_sample_app/.lintstagedrc.json
+++ b/apps/my_sample_app/.lintstagedrc.json
@@ -1,0 +1,7 @@
+{
+  "*.{js,jsx,ts,tsx}": [
+    "bash -c \"tsc -p ./tsconfig.json --noEmit\"",
+    "pnpm lint:fix",
+    "bash -c \"pnpm test\""
+  ]
+}

--- a/apps/my_sample_app/LICENSE
+++ b/apps/my_sample_app/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Commerce Layer Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/my_sample_app/README.md
+++ b/apps/my_sample_app/README.md
@@ -1,0 +1,19 @@
+# A brand new app
+
+Describe the new app in the `packages/index/src/appList.js` file:
+
+```js
+export const apps = {
+  ...
+  whatever_you_want: {
+    name: 'My sample app',
+    slug: 'my_sample_app',
+    kind: 'generic',
+    icon: 'wrench'
+  }
+}
+```
+
+Duplicate the application you wanna start from or start from scratch with `my_sample_app`.
+
+If you started from the "my sample app", remember to replace all occurrences of `my_sample_app` with the new slug.

--- a/apps/my_sample_app/i18n.d.ts
+++ b/apps/my_sample_app/i18n.d.ts
@@ -1,0 +1,10 @@
+import type en from '@commercelayer/app-elements/dist/locales/en'
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'translation'
+    resources: {
+      translation: typeof en
+    }
+  }
+}

--- a/apps/my_sample_app/index.html
+++ b/apps/my_sample_app/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commerce Layer</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://data.commercelayer.app/assets/images/favicons/favicon-32x32.png"
+    />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root-app"></div>
+
+    <script src="/config.local.js"></script>
+    <script src="/config.js"></script>
+
+    <script type="module" src="/src/main.tsx"></script>
+    
+    <script>
+      window.addEventListener('DOMContentLoaded', () => {
+        window.clApp_my_sample_app.init(document.getElementById('root-app'), {
+            organizationSlug: '%PUBLIC_SELF_HOSTED_SLUG%',
+            routerBase: '%PUBLIC_PROJECT_PATH%'
+          })
+      })
+    </script>
+  </body>
+</html>

--- a/apps/my_sample_app/package.json
+++ b/apps/my_sample_app/package.json
@@ -1,7 +1,17 @@
 {
   "private": true,
-  "name": "app-tags",
+  "name": "app-my_sample_app",
+  "description": "A Commerce Layer Single Page Application.",
   "version": "3.4.0",
+  "license": "MIT",
+  "keywords": [
+    "reactjs",
+    "jamstack",
+    "headless",
+    "ecommerce",
+    "api",
+    "commercelayer"
+  ],
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,11 +21,12 @@
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "ts:check": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "test:watch": "vitest --passWithNoTests"
+    "test:watch": "vitest --passWithNoTests",
+    "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
     "@commercelayer/app-elements": "^5.3.0",
-    "@commercelayer/sdk": "6.36.0",
+    "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",
     "react": "19.0.0",
@@ -34,6 +45,7 @@
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
+    "cronstrue": "^2.57.0",
     "eslint": "^8.57.1",
     "i18next": "^24.2.3",
     "jsdom": "^26.0.0",
@@ -42,5 +54,8 @@
     "vite": "^6.2.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.9"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/apps/my_sample_app/public/config.js
+++ b/apps/my_sample_app/public/config.js
@@ -1,0 +1,6 @@
+window.clAppConfig = Object.assign(
+  {
+    domain: 'commercelayer.io'
+  },
+  window.clAppConfig
+)

--- a/apps/my_sample_app/public/config.preview-prd.js
+++ b/apps/my_sample_app/public/config.preview-prd.js
@@ -1,0 +1,3 @@
+window.clAppConfig = {
+  domain: 'commercelayer.io'
+}

--- a/apps/my_sample_app/public/config.preview-stg.js
+++ b/apps/my_sample_app/public/config.preview-stg.js
@@ -1,0 +1,3 @@
+window.clAppConfig = {
+  domain: 'commercelayer.co'
+}

--- a/apps/my_sample_app/src/App.tsx
+++ b/apps/my_sample_app/src/App.tsx
@@ -1,0 +1,31 @@
+import { ErrorNotFound } from '#components/ErrorNotFound'
+import { appRoutes } from '#data/routes'
+import { EmptyState, HomePageLayout, Spacer } from '@commercelayer/app-elements'
+import type { FC } from 'react'
+import { Route, Router, Switch } from 'wouter'
+
+interface AppProps {
+  routerBase?: string
+}
+
+export const App: FC<AppProps> = ({ routerBase }) => {
+  return (
+    <Router base={routerBase}>
+      <Switch>
+        <Route path={appRoutes.home.path}>
+          <HomePageLayout title='My Sample App'>
+            <Spacer top='14'>
+              <EmptyState
+                title='Welcome'
+                description='This is a starter template. Start building your application by modifying this `App.tsx` component.'
+              />
+            </Spacer>
+          </HomePageLayout>
+        </Route>
+        <Route>
+          <ErrorNotFound />
+        </Route>
+      </Switch>
+    </Router>
+  )
+}

--- a/apps/my_sample_app/src/components/ErrorNotFound.tsx
+++ b/apps/my_sample_app/src/components/ErrorNotFound.tsx
@@ -1,0 +1,27 @@
+import { appRoutes } from '#data/routes'
+import {
+  Button,
+  EmptyState,
+  PageLayout,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import type { FC } from 'react'
+import { Link } from 'wouter'
+
+export const ErrorNotFound: FC = () => {
+  const { settings } = useTokenProvider()
+
+  return (
+    <PageLayout title='My Sample App' mode={settings.mode}>
+      <EmptyState
+        title='Not found'
+        description='We could not find the resource you are looking for.'
+        action={
+          <Link href={appRoutes.home.makePath({})}>
+            <Button variant='primary'>Go back</Button>
+          </Link>
+        }
+      />
+    </PageLayout>
+  )
+}

--- a/apps/my_sample_app/src/data/routes.ts
+++ b/apps/my_sample_app/src/data/routes.ts
@@ -1,0 +1,11 @@
+import { createRoute } from '@commercelayer/app-elements'
+
+export type AppRoute = keyof typeof appRoutes
+
+// Object to be used as source of truth to handel application routes
+// each page should correspond to a key and each key should have
+// a `path` property to be used as patter matching in <Route path> component
+// and `makePath` method to be used to generate the path used in navigation and links
+export const appRoutes = {
+  home: createRoute('/')
+}

--- a/apps/my_sample_app/src/env.d.ts
+++ b/apps/my_sample_app/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMeta {
+  env: {
+    PUBLIC_PROJECT_PATH?: string
+    DEV: boolean
+    PUBLIC_SELF_HOSTED_SLUG?: string
+  }
+}

--- a/apps/my_sample_app/src/main.tsx
+++ b/apps/my_sample_app/src/main.tsx
@@ -1,0 +1,49 @@
+import {
+  CoreSdkProvider,
+  ErrorBoundary,
+  I18NProvider,
+  MetaTags,
+  TokenProvider,
+  createApp,
+  type ClAppProps,
+  type TokenProviderAllowedAppSlug
+} from '@commercelayer/app-elements'
+import '@commercelayer/app-elements/style.css'
+import { StrictMode } from 'react'
+import { SWRConfig } from 'swr'
+import { App } from './App'
+
+const isDev = Boolean(import.meta.env.DEV)
+
+const appSlug: TokenProviderAllowedAppSlug = 'my_sample_app'
+
+const Main = (props: ClAppProps): React.JSX.Element => (
+  <StrictMode>
+    <ErrorBoundary hasContainer>
+      <SWRConfig
+        value={{
+          revalidateOnFocus: false
+        }}
+      >
+        <TokenProvider
+          kind='generic'
+          appSlug={appSlug}
+          devMode={isDev}
+          loadingElement={<div />}
+          {...props}
+        >
+          <I18NProvider>
+            <CoreSdkProvider>
+              <MetaTags />
+              <App routerBase={props?.routerBase} />
+            </CoreSdkProvider>
+          </I18NProvider>
+        </TokenProvider>
+      </SWRConfig>
+    </ErrorBoundary>
+  </StrictMode>
+)
+
+export default Main
+
+createApp(Main, appSlug)

--- a/apps/my_sample_app/tsconfig.json
+++ b/apps/my_sample_app/tsconfig.json
@@ -1,0 +1,65 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "types": [
+      "vitest/globals",
+      "vite/client"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "verbatimModuleSyntax": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "#components/*": [
+        "src/components/*"
+      ],
+      "#pages/*": [
+        "src/pages/*"
+      ],
+      "#data/*": [
+        "src/data/*"
+      ],
+      "#hooks/*": [
+        "src/hooks/*"
+      ],
+      "#mocks": [
+        "src/mocks/index"
+      ],
+      "#utils/*": [
+        "src/utils/*"
+      ],
+    },
+    "incremental": true
+  },
+  "include": [
+    "vite.config.js",
+    "i18n.d.ts",
+    "src",
+    ".eslintrc.cjs",
+    "@typing/**/*.d.ts",
+    "public/config*.js"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/apps/my_sample_app/tsconfig.node.json
+++ b/apps/my_sample_app/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "vite.config.mts"
+  ]
+}

--- a/apps/my_sample_app/vite.config.js
+++ b/apps/my_sample_app/vite.config.js
@@ -1,0 +1,3 @@
+// @ts-check
+import { defineConfig } from '@commercelayer/app-builder/vite.config'
+export default defineConfig('my_sample_app')

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.2.1",
+    "@commercelayer/app-elements": "^5.3.0",
     "lodash-es": "^4.17.21",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "^5.1.8",
+    "@commercelayer/app-elements": "^5.2.1",
     "lodash-es": "^4.17.21",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/packages/index/src/appList.js
+++ b/packages/index/src/appList.js
@@ -1,16 +1,21 @@
 // @ts-check
 
 /**
- * A number, or a string containing a number.
- * @typedef {Exclude<import('@commercelayer/app-elements').TokenProviderAllowedApp, 'dashboard' | 'resources' >} AllowedAppKind
+ * Allowed app kinds.
+ * @typedef {import('@commercelayer/app-elements').TokenProviderTokenApplicationKind} AllowedAppKind
  */
 
 /**
- * A number, or a string containing a number.
- * @typedef {{ name: string; slug: string, kind: AllowedAppKind; icon: import('@commercelayer/app-elements').IconProps['name'] }} App
+ * Allowed app slug.
+ * @typedef {import('@commercelayer/app-elements').TokenProviderAllowedAppSlug} AllowedAppSlug
  */
 
-/** @type {Record<App['slug'], App>} */
+/**
+ * The App type.
+ * @typedef {{ name: string; slug: AllowedAppSlug, kind: AllowedAppKind; icon: import('@commercelayer/app-elements').IconProps['name'] }} App
+ */
+
+/** @type {Record<string, App>} */
 export const apps = {
   orders: {
     name: 'Orders',
@@ -113,5 +118,11 @@ export const apps = {
     slug: 'subscriptions',
     kind: 'subscriptions',
     icon: 'calendarCheck'
+  },
+  whatever_you_want: {
+    name: 'My sample app',
+    slug: 'my_sample_app',
+    kind: 'generic',
+    icon: 'appWindow'
   }
 }

--- a/packages/index/src/appList.js
+++ b/packages/index/src/appList.js
@@ -2,99 +2,116 @@
 
 /**
  * A number, or a string containing a number.
- * @typedef {Exclude<import('@commercelayer/app-elements').TokenProviderAllowedApp, 'dashboard' | 'resources'>} AllowedAppSlug
+ * @typedef {Exclude<import('@commercelayer/app-elements').TokenProviderAllowedApp, 'dashboard' | 'resources' >} AllowedAppKind
  */
 
 /**
  * A number, or a string containing a number.
- * @typedef {{ name: string; slug: AllowedAppSlug; icon: import('@commercelayer/app-elements').IconProps['name'] }} App
+ * @typedef {{ name: string; slug: string, kind: AllowedAppKind; icon: import('@commercelayer/app-elements').IconProps['name'] }} App
  */
 
-/** @type {Record<AllowedAppSlug, App>} */
+/** @type {Record<App['slug'], App>} */
 export const apps = {
   orders: {
     name: 'Orders',
     slug: 'orders',
+    kind: 'orders',
     icon: 'shoppingBag'
   },
   shipments: {
     name: 'Shipments',
     slug: 'shipments',
+    kind: 'shipments',
     icon: 'package'
   },
   customers: {
     name: 'Customers',
     slug: 'customers',
+    kind: 'customers',
     icon: 'users'
   },
   returns: {
     name: 'Returns',
     slug: 'returns',
+    kind: 'returns',
     icon: 'arrowUUpLeft'
   },
   stock_transfers: {
     name: 'Stock transfers',
     slug: 'stock_transfers',
+    kind: 'stock_transfers',
     icon: 'arrowsLeftRight'
   },
   skus: {
     name: 'SKUs',
     slug: 'skus',
+    kind: 'skus',
     icon: 'tShirt'
   },
   sku_lists: {
     name: 'SKU Lists',
     slug: 'sku_lists',
+    kind: 'sku_lists',
     icon: 'clipboardText'
   },
   imports: {
     name: 'Imports',
     slug: 'imports',
+    kind: 'imports',
     icon: 'download'
   },
   exports: {
     name: 'Exports',
     slug: 'exports',
+    kind: 'exports',
     icon: 'upload'
   },
   webhooks: {
     name: 'Webhooks',
     slug: 'webhooks',
+    kind: 'webhooks',
     icon: 'webhooksLogo'
   },
   tags: {
     name: 'Tags',
     slug: 'tags',
+    kind: 'tags',
     icon: 'tag'
   },
   bundles: {
     name: 'Bundles',
     slug: 'bundles',
+    kind: 'bundles',
     icon: 'shapes'
   },
   gift_cards: {
     name: 'Gift cards',
     slug: 'gift_cards',
+    kind: 'gift_cards',
     icon: 'gift'
   },
   inventory: {
     name: 'Inventory',
     slug: 'inventory',
+    kind: 'inventory',
     icon: 'warehouse'
   },
   price_lists: {
     name: 'Price lists',
     slug: 'price_lists',
+    kind: 'price_lists',
     icon: 'receipt'
   },
   promotions: {
     name: 'Promotions',
     slug: 'promotions',
+    kind: 'promotions',
     icon: 'seal'
   },
   subscriptions: {
     name: 'Subscriptions',
     slug: 'subscriptions',
+    kind: 'subscriptions',
     icon: 'calendarCheck'
   }
 }

--- a/packages/index/src/apps.ts
+++ b/packages/index/src/apps.ts
@@ -1,6 +1,6 @@
 import type { ClAppProps } from '@commercelayer/app-elements'
 import { lazy, type FC, type LazyExoticComponent } from 'react'
-import { apps, type AllowedAppSlug, type App } from './appList'
+import { apps, type App } from './appList'
 
 export const appLazyImports = Object.values(apps).reduce(
   (acc, app) => {
@@ -12,7 +12,7 @@ export const appLazyImports = Object.values(apps).reduce(
     }
   },
   // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter, @typescript-eslint/consistent-type-assertions
-  {} as Record<AllowedAppSlug, LazyExoticComponent<FC<ClAppProps>>>
+  {} as Record<App['slug'], LazyExoticComponent<FC<ClAppProps>>>
 )
 
 export const appPromiseImports = Object.values(apps).reduce(
@@ -29,7 +29,7 @@ export const appPromiseImports = Object.values(apps).reduce(
     }
   },
   // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter, @typescript-eslint/consistent-type-assertions
-  {} as Record<AllowedAppSlug, { app: App; exists: () => Promise<boolean> }>
+  {} as Record<App['slug'], { app: App; exists: () => Promise<boolean> }>
 )
 
 /**

--- a/packages/index/src/main.tsx
+++ b/packages/index/src/main.tsx
@@ -2,8 +2,4 @@ import { createApp } from '@commercelayer/app-elements'
 import '@commercelayer/app-elements/style.css'
 import { App } from './App'
 
-createApp(
-  (props) => <App {...props} />,
-  // @ts-expect-error This is an hack.
-  'index'
-)
+createApp((props) => <App {...props} />, 'index')

--- a/packages/index/src/pages/HomePage.tsx
+++ b/packages/index/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import {
 import { jwtDecode } from '@commercelayer/js-auth'
 import Cookies from 'js-cookie'
 import { useEffect, useState } from 'react'
-import type { App } from 'src/appList'
+import type { App } from '../appList'
 import { appPromiseImports, humanReadable } from '../apps'
 
 export function HomePage(): React.JSX.Element {

--- a/packages/index/src/pages/HomePage.tsx
+++ b/packages/index/src/pages/HomePage.tsx
@@ -9,12 +9,12 @@ import {
 import { jwtDecode } from '@commercelayer/js-auth'
 import Cookies from 'js-cookie'
 import { useEffect, useState } from 'react'
-import { type AllowedAppSlug } from '../appList'
+import type { App } from 'src/appList'
 import { appPromiseImports, humanReadable } from '../apps'
 
 export function HomePage(): React.JSX.Element {
   const [visibility, setVisibility] = useState<
-    Partial<Record<AllowedAppSlug, boolean>>
+    Partial<Record<App['slug'], boolean>>
   >({})
   const [accessToken, setAccessToken] = useState<string | null>()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -115,8 +115,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -197,8 +197,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
@@ -288,8 +288,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -370,8 +370,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
@@ -464,8 +464,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -546,11 +546,96 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9(@types/node@22.13.4)(jsdom@26.0.0)(yaml@2.7.0)
 
+  apps/my_sample_app:
+    dependencies:
+      '@commercelayer/app-elements':
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+      '@commercelayer/sdk':
+        specifier: ^6.36.0
+        version: 6.36.0
+      '@hookform/resolvers':
+        specifier: ^3.10.0
+        version: 3.10.0(react-hook-form@7.54.2(react@19.0.0))
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+      react-hook-form:
+        specifier: 7.54.2
+        version: 7.54.2(react@19.0.0)
+      swr:
+        specifier: ^2.3.3
+        version: 2.3.3(react@19.0.0)
+      type-fest:
+        specifier: ^4.38.0
+        version: 4.38.0
+      wouter:
+        specifier: ^3.6.0
+        version: 3.6.0(react@19.0.0)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+    devDependencies:
+      '@commercelayer/app-builder':
+        specifier: workspace:*
+        version: link:../../packages/app-builder
+      '@commercelayer/eslint-config-ts-react':
+        specifier: ^2.2.0
+        version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
+      '@types/node':
+        specifier: 22.13.4
+        version: 22.13.4
+      '@types/react':
+        specifier: ^19.0.12
+        version: 19.0.12
+      '@types/react-dom':
+        specifier: ^19.0.4
+        version: 19.0.4(@types/react@19.0.12)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.2.3(@types/node@22.13.4)(yaml@2.7.0))
+      cronstrue:
+        specifier: ^2.57.0
+        version: 2.57.0
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      i18next:
+        specifier: ^24.2.3
+        version: 24.2.3(typescript@5.8.2)
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.0.0
+      rollup-plugin-external-globals:
+        specifier: ^0.13.0
+        version: 0.13.0(rollup@4.34.8)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
+      vite:
+        specifier: ^6.2.3
+        version: 6.2.3(@types/node@22.13.4)(yaml@2.7.0)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.2)(vite@6.2.3(@types/node@22.13.4)(yaml@2.7.0))
+      vitest:
+        specifier: ^3.0.9
+        version: 3.0.9(@types/node@22.13.4)(jsdom@26.0.0)(yaml@2.7.0)
+
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -637,8 +722,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -722,8 +807,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -810,8 +895,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -895,8 +980,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -980,8 +1065,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1068,8 +1153,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1159,8 +1244,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1241,8 +1326,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -1326,8 +1411,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1408,8 +1493,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1514,8 +1599,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -1572,8 +1657,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.2.1
-        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.3.0
+        version: 5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1740,8 +1825,8 @@ packages:
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
 
-  '@commercelayer/app-elements@5.2.1':
-    resolution: {integrity: sha512-TIU+N5CRvwU/Fuh7yWFy5gtvs5qKFYYJ35mXucm3eamIVstc5vcDSIbmGmtNGS1sTdNNZ0GydN9rc4DNkfVKJQ==}
+  '@commercelayer/app-elements@5.3.0':
+    resolution: {integrity: sha512-BKCZ7cGEleYWxlL4WaRMBykgEfiETso+wgfS1ebpVAcE+aEQOAj4wH9m3fM9bpxDBfMT9miaSyD/xcuFx3Hk0A==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -6149,7 +6234,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@commercelayer/app-elements@5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))':
+  '@commercelayer/app-elements@5.3.0(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))':
     dependencies:
       '@commercelayer/js-auth': 6.7.1
       '@commercelayer/sdk': 6.36.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -115,8 +115,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -197,8 +197,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
@@ -288,8 +288,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -370,8 +370,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
@@ -464,8 +464,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -549,8 +549,8 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -637,8 +637,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -722,8 +722,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -810,8 +810,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -895,8 +895,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -980,8 +980,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1068,8 +1068,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1159,8 +1159,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1241,8 +1241,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -1326,8 +1326,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1408,8 +1408,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1514,8 +1514,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -1572,8 +1572,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: ^5.1.8
-        version: 5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: ^5.2.1
+        version: 5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1740,8 +1740,8 @@ packages:
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
 
-  '@commercelayer/app-elements@5.1.8':
-    resolution: {integrity: sha512-9KFikblHLrPPrvyObWi0s84OR+kTFYW9f9avsEPlClyKVRMyhoBc3F/Guarx44CxWYFAMePsFA2HIUfrQYrKHg==}
+  '@commercelayer/app-elements@5.2.1':
+    resolution: {integrity: sha512-TIU+N5CRvwU/Fuh7yWFy5gtvs5qKFYYJ35mXucm3eamIVstc5vcDSIbmGmtNGS1sTdNNZ0GydN9rc4DNkfVKJQ==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -1800,6 +1800,9 @@ packages:
   '@csstools/css-tokenizer@3.0.3':
     resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
     engines: {node: '>=18'}
+
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
 
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
@@ -6146,10 +6149,11 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@commercelayer/app-elements@5.1.8(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))':
+  '@commercelayer/app-elements@5.2.1(@commercelayer/sdk@6.36.0)(monaco-editor@0.52.2)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))':
     dependencies:
       '@commercelayer/js-auth': 6.7.1
       '@commercelayer/sdk': 6.36.0
+      '@date-fns/tz': 1.2.0
       '@monaco-editor/react': 4.7.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/lodash-es': 4.17.12
       '@types/react': 19.0.12
@@ -6241,6 +6245,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-tokenizer@3.0.3': {}
+
+  '@date-fns/tz@1.2.0': {}
 
   '@emnapi/core@1.3.1':
     dependencies:


### PR DESCRIPTION
## What I did

This PR enables support for `generic` applications and introduces a new example: `my sample app`. This sample application serves as a reference implementation, demonstrating how to create a new app from scratch using the updated generic app support.
