### PR TITLE
Implement new RuleEngine component in the promotion app

### DIFF
--- a/apps/promotions/src/components/FlexRuleBuilder.tsx
+++ b/apps/promotions/src/components/FlexRuleBuilder.tsx
@@ -1,0 +1,257 @@
+import type { Promotion } from '#types'
+import {
+  Button,
+  Card,
+  Hr,
+  Icon,
+  isMockedId,
+  ListItem,
+  RuleEngine,
+  Section,
+  Spacer,
+  Text,
+  toast,
+  useCoreSdkProvider,
+  useOverlay,
+  useTokenProvider
+} from '@commercelayer/app-elements'
+import type { FlexPromotion } from '@commercelayer/sdk'
+import { useEffect, useState } from 'react'
+
+interface PromotionRules {
+  rules: Array<{ id: string; name: string }>
+}
+
+export function SectionFlexRules({
+  promotion,
+  onChange
+}: {
+  promotion: Extract<Promotion, FlexPromotion>
+  onChange?: (rules: PromotionRules) => void
+}): React.JSX.Element {
+  const isNewPromotion = isMockedId(promotion.id)
+  const { Overlay, open, close } = useOverlay({ queryParam: 'rule-builder' })
+  const [promotionRules, setPromotionRules] = useState<PromotionRules>(
+    promotion.rules as PromotionRules
+  )
+  const [ruleIsSet, setRuleIsSet] = useState(!isNewPromotion)
+  const { sdkClient } = useCoreSdkProvider()
+  const {
+    settings: { accessToken, organizationSlug, domain }
+  } = useTokenProvider()
+
+  const hasRulesToShow = promotionRules.rules.length > 0 && ruleIsSet
+
+  useEffect(
+    function handlePromotionRulesChange() {
+      onChange?.(promotionRules)
+    },
+    [promotionRules]
+  )
+
+  const emptyList = (
+    <ListItem
+      alignIcon='center'
+      icon={<Icon name='treeView' size={32} />}
+      paddingSize='6'
+      variant='boxed'
+    >
+      <Text>
+        Start by selecting the actions to apply, then define the conditions that
+        will trigger them.
+      </Text>
+      <Button
+        type='button'
+        alignItems='center'
+        size='small'
+        variant='secondary'
+        onClick={() => {
+          open()
+        }}
+      >
+        <Icon name='plus' size={16} />
+        Add rules
+      </Button>
+    </ListItem>
+  )
+
+  const ruleListCard = (
+    <Card overflow='visible' gap='4'>
+      {promotionRules.rules.map((item, index, arr) => {
+        const idx = `#${(index + 1).toString().padStart(2, '0')}`
+        return (
+          <div key={item.id}>
+            <div>
+              <b className='pr-4'>{idx}</b> {item.name}
+            </div>
+            {index < arr.length - 1 ? (
+              <Spacer top='4' bottom='4'>
+                <Hr style={{ borderStyle: 'dashed' }} />
+              </Spacer>
+            ) : null}
+          </div>
+        )
+      })}
+    </Card>
+  )
+
+  const ruleList = hasRulesToShow ? (
+    isNewPromotion ? (
+      ruleListCard
+    ) : (
+      <Card backgroundColor='light' overflow='visible' gap='4'>
+        {ruleListCard}
+      </Card>
+    )
+  ) : (
+    emptyList
+  )
+
+  return (
+    <Section
+      title='Rules'
+      border='none'
+      actionButton={
+        hasRulesToShow ? (
+          <Button
+            type='button'
+            onClick={() => {
+              open()
+            }}
+            variant='secondary'
+            size='mini'
+            alignItems='center'
+          >
+            <Icon name='pencilSimple' />
+            Edit
+          </Button>
+        ) : null
+      }
+    >
+      <Overlay fullWidth>
+        <header
+          style={{ height: '64px' }}
+          className='border-b border-gray-200 flex items-center justify-between px-6'
+        >
+          <div className='flex items-center gap-3'>
+            <img
+              src='https://data.commercelayer.app/assets/logos/glyph/black/commercelayer_glyph_black.svg'
+              alt='Commerce Layer glyph in black'
+              width={28}
+            />
+            <Text size='regular' weight='semibold'>
+              Rules
+            </Text>
+          </div>
+          <div className='flex items-center gap-6'>
+            <a
+              href='https://docs.commercelayer.io/rules-engine'
+              target='_blank'
+              style={{ height: '36px', alignContent: 'center' }}
+              className='border-r px-4'
+              rel='noreferrer'
+            >
+              <Text
+                size='small'
+                variant='info'
+                weight='semibold'
+                className='flex items-center gap-1'
+              >
+                <Icon name='question' size={16} />
+                Do you need help?
+              </Text>
+            </a>
+
+            <Button
+              variant='link'
+              alignItems='center'
+              onClick={() => {
+                setPromotionRules(promotion.rules as PromotionRules)
+                close()
+              }}
+            >
+              <Icon name='arrowLeft' />
+              <Text size='small' weight='semibold'>
+                Back to promotion
+              </Text>
+            </Button>
+
+            <Button
+              size='small'
+              onClick={() => {
+                if (isNewPromotion) {
+                  void fetch(
+                    `https://${organizationSlug}.${domain}/api/rules/check`,
+                    {
+                      method: 'POST',
+                      headers: {
+                        Accept: 'application/vnd.api+json',
+                        'Content-Type': 'application/vnd.api+json',
+                        Authorization: `Bearer ${accessToken}`
+                      },
+                      body: JSON.stringify({
+                        rules: promotionRules.rules,
+                        payload: [{}]
+                      })
+                    }
+                  )
+                    .then(async (res) => await res.json())
+                    .then((json) => {
+                      if ('errors' in json && json.errors.length > 0) {
+                        const detail: string | undefined =
+                          json?.errors?.[0]?.detail
+                        toast(detail ?? 'An error occurred', { type: 'error' })
+                        return json
+                      }
+
+                      setRuleIsSet(true)
+                      close()
+                    })
+                    .catch((error) => {
+                      const title: string | undefined =
+                        error?.errors?.[0]?.title
+                      toast(title ?? 'An error occurred', { type: 'error' })
+
+                      throw error
+                    })
+                } else {
+                  void sdkClient.flex_promotions
+                    .update({
+                      id: promotion.id,
+                      rules: promotionRules
+                    })
+                    .then(() => {
+                      setRuleIsSet(true)
+                      close()
+                    })
+                    .catch((error) => {
+                      const title: string | undefined =
+                        error?.errors?.[0]?.title
+                      toast(title ?? 'An error occurred', { type: 'error' })
+
+                      throw error
+                    })
+                }
+              }}
+            >
+              Save rules
+            </Button>
+          </div>
+        </header>
+        <div
+          style={{ height: 'calc(100vh - 64px)' }}
+          className='overflow-y-auto'
+        >
+          <RuleEngine
+            defaultValue={JSON.stringify(promotionRules)}
+            defaultCodeEditorVisible
+            onChange={(rules) => {
+              setPromotionRules(rules as PromotionRules)
+            }}
+          />
+        </div>
+      </Overlay>
+      {ruleList}
+    </Section>
+  )
+}

--- a/apps/promotions/src/components/PromotionForm.tsx
+++ b/apps/promotions/src/components/PromotionForm.tsx
@@ -125,8 +125,11 @@ export function PromotionForm({
             </Grid>
           </Spacer>
 
-          {/* @ts-expect-error // TODO: I need to fix this */}
-          <promotionConfig.Fields promotion={promotion} />
+          <promotionConfig.Fields
+            // @ts-expect-error // TODO: I need to fix this
+            promotion={promotion}
+            hookFormReturn={methods}
+          />
 
           <Spacer top='6'>
             <HookedInput
@@ -139,15 +142,14 @@ export function PromotionForm({
               }}
             />
           </Spacer>
-
-          <Spacer top='6'>
-            <HookedInput name='reference' label='Reference' />
-          </Spacer>
         </Section>
       </Spacer>
 
-      {/* @ts-expect-error // TODO: I need to fix this */}
-      <promotionConfig.Options promotion={promotion} />
+      <promotionConfig.Options
+        // @ts-expect-error // TODO: I need to fix this
+        promotion={promotion}
+        hookFormReturn={methods}
+      />
 
       <Spacer top='14'>
         <Section title='How this promotion works with concurrent ones'>

--- a/apps/promotions/src/data/formConverters/promotion.ts
+++ b/apps/promotions/src/data/formConverters/promotion.ts
@@ -12,11 +12,7 @@ export function promotionToFormValues(promotion?: Promotion) {
     ...promotion,
     starts_at: new Date(promotion.starts_at),
     expires_at: new Date(promotion.expires_at),
-    show_priority: promotion.priority != null,
-    reference:
-      promotion.reference != null && promotion.reference !== ''
-        ? promotion.reference
-        : null
+    show_priority: promotion.priority != null
   }
 
   if (promotion.type === 'flex_promotions') {
@@ -52,12 +48,6 @@ export function formValuesToPromotion(
     total_usage_limit:
       'total_usage_limit' in formValues && formValues.total_usage_limit != null
         ? formValues.total_usage_limit
-        : null,
-    reference:
-      'reference' in formValues &&
-      formValues.reference != null &&
-      formValues.reference !== ''
-        ? formValues.reference
         : null,
     rules:
       'rules' in formValues && formValues.rules != null

--- a/apps/promotions/src/data/promotions/config.tsx
+++ b/apps/promotions/src/data/promotions/config.tsx
@@ -1,6 +1,7 @@
 import type { Promotion } from '#types'
 import { type IconProps } from '@commercelayer/app-elements'
 import type { ResourceTypeLock } from '@commercelayer/sdk'
+import type { UseFormReturn } from 'react-hook-form'
 import type { Replace } from 'type-fest'
 import { type z } from 'zod'
 import buy_x_pay_y_promotions from './configs/buy_x_pay_y_promotions'
@@ -50,8 +51,14 @@ export type PromotionConfig = {
       promotion: Extract<Promotion, { type: type }>
     }>
     formType: z.ZodObject<z.ZodRawShape, 'strip', z.ZodTypeAny>
-    Fields: React.FC<{ promotion?: Extract<Promotion, { type: type }> }>
-    Options: React.FC<{ promotion?: Extract<Promotion, { type: type }> }>
+    Fields: React.FC<{
+      promotion?: Extract<Promotion, { type: type }>
+      hookFormReturn: UseFormReturn<Record<string, any>, any, undefined>
+    }>
+    Options: React.FC<{
+      promotion?: Extract<Promotion, { type: type }>
+      hookFormReturn: UseFormReturn<Record<string, any>, any, undefined>
+    }>
     DetailsSectionInfo: React.FC<{
       promotion: Extract<Promotion, { type: type }>
     }>

--- a/apps/promotions/src/data/promotions/configs/flex_promotions.tsx
+++ b/apps/promotions/src/data/promotions/configs/flex_promotions.tsx
@@ -1,4 +1,10 @@
-import { HookedCodeEditor, Spacer } from '@commercelayer/app-elements'
+import { SectionFlexRules } from '#components/FlexRuleBuilder'
+import { makeFlexPromotion } from '#mocks'
+import {
+  InputFeedback,
+  Spacer,
+  useValidationFeedback
+} from '@commercelayer/app-elements'
 import { z } from 'zod'
 import type { PromotionConfig } from '../config'
 import { genericPromotionOptions } from './promotions'
@@ -7,9 +13,10 @@ export default {
   flex_promotions: {
     type: 'flex_promotions',
     slug: 'flex',
-    icon: 'asteriskSimple',
+    icon: 'target',
     titleList: 'Flex promotion',
-    description: 'A powerful flex promotion.',
+    description:
+      'Create advanced promotions with flexible conditions using the rules engine.',
     titleNew: 'flex promotion',
     formType: genericPromotionOptions.merge(
       z.object({
@@ -25,20 +32,30 @@ export default {
         }, 'JSON is not valid')
       })
     ),
-    Fields: () => (
-      <>
-        <Spacer top='6'>
-          <HookedCodeEditor
-            name='rules'
-            label='Rules'
-            language='json'
-            jsonSchema='order-rules'
-            height='600px'
-          />
-        </Spacer>
-      </>
-    ),
-    Options: () => <></>,
+    Options: ({ promotion, hookFormReturn }) => {
+      const feedback = useValidationFeedback('rules')
+      return (
+        <>
+          {promotion == null && (
+            <Spacer top='14'>
+              <SectionFlexRules
+                promotion={makeFlexPromotion()}
+                onChange={(rules) => {
+                  hookFormReturn.setValue(
+                    'rules',
+                    JSON.stringify(rules, null, 2)
+                  )
+                }}
+              />
+              {feedback != null && (
+                <InputFeedback className='mt-2' {...feedback} />
+              )}
+            </Spacer>
+          )}
+        </>
+      )
+    },
+    Fields: () => <></>,
     StatusDescription: () => <>Flex</>,
     DetailsSectionInfo: () => <></>
   }

--- a/apps/promotions/src/data/promotions/configs/promotions.tsx
+++ b/apps/promotions/src/data/promotions/configs/promotions.tsx
@@ -4,7 +4,6 @@ export const genericPromotionOptions = z.object({
   name: z.string().min(1),
   starts_at: z.date(),
   expires_at: z.date(),
-  reference: z.string().nullish(),
   total_usage_limit: z.preprocess((value) => {
     return Number.isNaN(value) ? null : value
   }, z.number().min(1).nullish()),

--- a/apps/promotions/src/main.tsx
+++ b/apps/promotions/src/main.tsx
@@ -3,6 +3,7 @@ import {
   ErrorBoundary,
   I18NProvider,
   MetaTags,
+  ToastContainer,
   TokenProvider,
   createApp,
   type ClAppProps
@@ -33,6 +34,7 @@ const Main = (props: ClAppProps): React.JSX.Element => {
             <I18NProvider>
               <CoreSdkProvider>
                 <MetaTags />
+                <ToastContainer />
                 <App routerBase={props?.routerBase} />
               </CoreSdkProvider>
             </I18NProvider>

--- a/apps/promotions/src/mocks/index.ts
+++ b/apps/promotions/src/mocks/index.ts
@@ -1,4 +1,5 @@
 export * from './resources/custom_promotion_rules'
+export * from './resources/flex_promotions'
 export * from './resources/markets'
 export * from './resources/percentage_discount_promotions'
 export * from './resources/price_lists'

--- a/apps/promotions/src/mocks/resources/flex_promotions.ts
+++ b/apps/promotions/src/mocks/resources/flex_promotions.ts
@@ -1,0 +1,24 @@
+import type { Promotion } from '#types'
+import { makeResource } from '../resource'
+
+export const makeFlexPromotion = (
+  overrides?: Partial<Extract<Promotion, { type: 'flex_promotions' }>>
+): Extract<Promotion, { type: 'flex_promotions' }> => {
+  return {
+    ...makeResource(),
+    type: 'flex_promotions',
+    name: 'Example',
+    starts_at: new Date().toJSON(),
+    expires_at: new Date().toJSON(),
+    rules: {
+      rules: [
+        {
+          name: 'Rule name',
+          actions: [null],
+          conditions: [null]
+        }
+      ]
+    },
+    ...overrides
+  }
+}

--- a/apps/promotions/src/pages/NewSelectTypePage.tsx
+++ b/apps/promotions/src/pages/NewSelectTypePage.tsx
@@ -54,10 +54,10 @@ function Page(
         </Section>
       </Spacer>
       <Spacer top='10'>
-        <Section titleSize='small' title='More' border='none'>
-          <Grid columns={hasRuleEngine ? '2' : '1'}>
-            <LinkTo promotionType='external_promotions' />
+        <Section titleSize='small' title='Advanced' border='none'>
+          <Grid columns='1'>
             {hasRuleEngine && <LinkTo promotionType='flex_promotions' />}
+            <LinkTo promotionType='external_promotions' />
           </Grid>
         </Section>
       </Spacer>

--- a/apps/promotions/src/pages/PromotionDetailsPage.tsx
+++ b/apps/promotions/src/pages/PromotionDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { CouponTable } from '#components/CouponTable'
+import { SectionFlexRules } from '#components/FlexRuleBuilder'
 import { GenericPageNotFound, type PageProps } from '#components/Routes'
 import {
   appPromotionsReferenceOrigin,
@@ -16,7 +17,6 @@ import {
   Badge,
   Button,
   Card,
-  CodeEditor,
   Dropdown,
   DropdownItem,
   Icon,
@@ -174,7 +174,7 @@ function Page(
               </Alert>
             )}
 
-          {viaApi && (
+          {viaApi && promotion.type !== 'flex_promotions' && (
             <Alert status='info'>
               This promotion is generated via API. Ask developers for details.
               If issues arise, just disable it.
@@ -191,17 +191,11 @@ function Page(
         </Spacer>
 
         {promotion.type === 'flex_promotions' && (
-          <Spacer top='14'>
-            <Section title='Rules' border='none'>
-              <CodeEditor
-                readOnly
-                value={JSON.stringify(promotion.rules, undefined, 2)}
-                language='json'
-                jsonSchema='order-rules'
-                height='600px'
-              />
-            </Section>
-          </Spacer>
+          <>
+            <Spacer top='14'>
+              <SectionFlexRules promotion={promotion} />
+            </Spacer>
+          </>
         )}
 
         {promotion.type !== 'flex_promotions' && (
@@ -495,11 +489,6 @@ const SectionInfo = withSkeletonTemplate<{
       {promotion.priority != null && (
         <ListDetailsItem label='Priority' gutter='none'>
           {promotion.priority}
-        </ListDetailsItem>
-      )}
-      {promotion.reference != null && promotion.reference !== '' && (
-        <ListDetailsItem label='Reference' gutter='none'>
-          {promotion.reference}
         </ListDetailsItem>
       )}
     </Section>


### PR DESCRIPTION
Part of commercelayer/issues-app#370

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added the new `RuleEngine` component to the promotion app. Now, when a user creates a Flex Promotion, they can also use the builder.

<img width="1415" height="1011" alt="Screenshot 2025-07-18 alle 10 14 23" src="https://github.com/user-attachments/assets/cddccc51-fd4f-42bc-b4ec-799c615e11df" />

