### PR TITLE
Use external prices in order new/edit if enabled in market

### DIFF
--- a/apps/orders/src/components/OrderSummary/HeaderActions.tsx
+++ b/apps/orders/src/components/OrderSummary/HeaderActions.tsx
@@ -5,6 +5,7 @@ import {
   Dropdown,
   DropdownItem,
   Icon,
+  useCoreApi,
   useCoreSdkProvider,
   useTokenProvider,
   useTranslation
@@ -24,7 +25,11 @@ export const HeaderActions: React.FC<{ order: Order }> = ({ order }) => {
   const { show: showAddItemOverlay, Overlay: AddItemOverlay } =
     useAddItemOverlay(order)
   const { t } = useTranslation()
-  const hasExternalPrices = !isEmpty(order.market?.external_prices_url)
+
+  const { data: organization } = useCoreApi('organization', 'retrieve', [])
+  const hasExternalPrices =
+    !isEmpty(order.market?.external_prices_url) &&
+    organization?.config?.apps?.orders?.external_price === true
 
   const canEdit =
     order.status === 'placed' &&


### PR DESCRIPTION
Closes commercelayer/issues-app#384

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

If the market uses external pricing, set `external_price: true` when creating a line item. Either during order editing or when creating a new order.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
