### PR TITLE
Refactor `renderReturn` function as React FC in app-orders

### DIFF
--- a/apps/orders/src/components/OrderReturns.tsx
+++ b/apps/orders/src/components/OrderReturns.tsx
@@ -6,6 +6,7 @@ import {
   withSkeletonTemplate
 } from '@commercelayer/app-elements'
 import type { Return } from '@commercelayer/sdk'
+import type { FC } from 'react'
 
 interface Props {
   returns?: Return[]
@@ -21,7 +22,7 @@ const returnStatuses = [
   'refunded'
 ]
 
-const renderReturn = (returnObj: Return): React.JSX.Element | undefined => {
+const ReturnListItem: FC<{ returnObj: Return }> = ({ returnObj }) => {
   const { canAccess } = useTokenProvider()
   const { navigateTo } = useAppLinking()
 
@@ -58,7 +59,9 @@ export const OrderReturns = withSkeletonTemplate<Props>(({ returns }) => {
 
   return (
     <Section title='Returns'>
-      {returns.map((returnObj) => renderReturn(returnObj))}
+      {returns.map((returnObj) => (
+        <ReturnListItem key={returnObj.id} returnObj={returnObj} />
+      ))}
     </Section>
   )
 })


### PR DESCRIPTION
Closes commercelayer/issues-app#397

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've refactored the `renderReturn` function as React Functional Component. 
Since the function uses some hooks it could generate the following error https://react.dev/errors/310


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
