### PR TITLE
App shipments improvements (filters lists, show reference and packing form adjustments)

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.36.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.36.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/my_sample_app/package.json
+++ b/apps/my_sample_app/package.json
@@ -25,7 +25,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/shipments/src/components/FormPackingFieldWeight.tsx
+++ b/apps/shipments/src/components/FormPackingFieldWeight.tsx
@@ -1,6 +1,5 @@
 import { useSyncFormPackingWeight } from '#hooks/useSyncFormPackingWeight'
 import {
-  Grid,
   HookedInput,
   HookedInputSelect,
   useTranslation
@@ -18,11 +17,13 @@ export function FormPackingFieldWeight({
   useSyncFormPackingWeight({ shipment })
 
   return (
-    <Grid columns='2'>
+    <div
+      style={{ display: 'grid', gap: '1rem', gridTemplateColumns: '2.5fr 1fr' }}
+    >
       <HookedInput label={t('apps.shipments.details.weight')} name='weight' />
       <HookedInputSelect
         name='unitOfWeight'
-        label='&nbsp;' // empty white space to keep field alignment
+        label={`\u00A0`} // empty white space to keep field alignment
         aria-label={t('apps.shipments.form.unit_of_weight')}
         key={watch('unitOfWeight')}
         initialValues={[
@@ -46,6 +47,6 @@ export function FormPackingFieldWeight({
           }
         ]}
       />
-    </Grid>
+    </div>
   )
 }

--- a/apps/shipments/src/components/FormPackingFieldWeight.tsx
+++ b/apps/shipments/src/components/FormPackingFieldWeight.tsx
@@ -22,7 +22,8 @@ export function FormPackingFieldWeight({
       <HookedInput label={t('apps.shipments.details.weight')} name='weight' />
       <HookedInputSelect
         name='unitOfWeight'
-        label={t('apps.shipments.form.unit_of_weight')}
+        label='&nbsp;' // empty white space to keep field alignment
+        aria-label={t('apps.shipments.form.unit_of_weight')}
         key={watch('unitOfWeight')}
         initialValues={[
           {

--- a/apps/shipments/src/data/filters.ts
+++ b/apps/shipments/src/data/filters.ts
@@ -14,81 +14,87 @@ const allowedStatuses: Array<Shipment['status']> = [
 
 const textSearchPredicate = ['number', 'reference'].join('_or_') + '_cont'
 
-export const filtersInstructions: FiltersInstructions = [
-  {
-    label: t('resources.stock_locations.name_other'),
-    type: 'options',
-    sdk: {
-      predicate: 'stock_location_id_in'
+export const makeFiltersInstructions = (options?: {
+  hideFilterStatus?: boolean
+}): FiltersInstructions => {
+  const hideFilterStatus = options?.hideFilterStatus ?? false
+  return [
+    {
+      label: t('resources.stock_locations.name_other'),
+      type: 'options',
+      sdk: {
+        predicate: 'stock_location_id_in'
+      },
+      render: {
+        component: 'inputResourceGroup',
+        props: {
+          resource: 'stock_locations',
+          fieldForLabel: 'name',
+          fieldForValue: 'id',
+          searchBy: 'name_cont',
+          sortBy: { attribute: 'updated_at', direction: 'desc' },
+          previewLimit: 5,
+          hideWhenSingleItem: true
+        }
+      }
     },
-    render: {
-      component: 'inputResourceGroup',
-      props: {
-        resource: 'stock_locations',
-        fieldForLabel: 'name',
-        fieldForValue: 'id',
-        searchBy: 'name_cont',
-        sortBy: { attribute: 'updated_at', direction: 'desc' },
-        previewLimit: 5,
-        hideWhenSingleItem: true
+    {
+      label: t('apps.shipments.attributes.status'),
+      type: 'options',
+      hidden: hideFilterStatus,
+      sdk: {
+        predicate: 'status_in',
+        defaultOptions: allowedStatuses
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: allowedStatuses.map((status) => ({
+            value: status,
+            label: getShipmentStatusName(status)
+          }))
+        }
+      }
+    },
+    {
+      label: t('common.time_range'),
+      type: 'timeRange',
+      sdk: {
+        predicate: 'updated_at'
+      },
+      render: {
+        component: 'dateRangePicker'
+      }
+    },
+    {
+      label: t('resources.tags.name_other'),
+      type: 'options',
+      sdk: {
+        predicate: 'tags_id_in'
+      },
+      render: {
+        component: 'inputResourceGroup',
+        props: {
+          fieldForLabel: 'name',
+          fieldForValue: 'id',
+          resource: 'tags',
+          searchBy: 'name_cont',
+          sortBy: { attribute: 'name', direction: 'asc' },
+          previewLimit: 5,
+          showCheckboxIcon: false
+        }
+      }
+    },
+    {
+      label: t('common.search'),
+      type: 'textSearch',
+      sdk: {
+        predicate: textSearchPredicate
+      },
+      render: {
+        component: 'searchBar'
       }
     }
-  },
-  {
-    label: t('apps.shipments.attributes.status'),
-    type: 'options',
-    sdk: {
-      predicate: 'status_in',
-      defaultOptions: allowedStatuses
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: allowedStatuses.map((status) => ({
-          value: status,
-          label: getShipmentStatusName(status)
-        }))
-      }
-    }
-  },
-  {
-    label: t('common.time_range'),
-    type: 'timeRange',
-    sdk: {
-      predicate: 'updated_at'
-    },
-    render: {
-      component: 'dateRangePicker'
-    }
-  },
-  {
-    label: t('resources.tags.name_other'),
-    type: 'options',
-    sdk: {
-      predicate: 'tags_id_in'
-    },
-    render: {
-      component: 'inputResourceGroup',
-      props: {
-        fieldForLabel: 'name',
-        fieldForValue: 'id',
-        resource: 'tags',
-        searchBy: 'name_cont',
-        sortBy: { attribute: 'name', direction: 'asc' },
-        previewLimit: 5,
-        showCheckboxIcon: false
-      }
-    }
-  },
-  {
-    label: t('common.search'),
-    type: 'textSearch',
-    sdk: {
-      predicate: textSearchPredicate
-    },
-    render: {
-      component: 'searchBar'
-    }
-  }
-]
+  ]
+}

--- a/apps/shipments/src/pages/Filters.tsx
+++ b/apps/shipments/src/pages/Filters.tsx
@@ -1,5 +1,4 @@
 import { makeFiltersInstructions } from '#data/filters'
-import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
   PageLayout,
@@ -15,11 +14,11 @@ function Filters(): React.JSX.Element {
   const queryString = useSearch()
   const params = new URLSearchParams(queryString)
   const viewTitle = params.get('viewTitle') ?? undefined
-  const isPickingPage = viewTitle === presets.picking.viewTitle
+  const isInViewPreset = viewTitle != null
 
   const { FiltersForm, adapters } = useResourceFilters({
     instructions: makeFiltersInstructions({
-      hideFilterStatus: isPickingPage
+      hideFilterStatus: isInViewPreset
     })
   })
 

--- a/apps/shipments/src/pages/Filters.tsx
+++ b/apps/shipments/src/pages/Filters.tsx
@@ -1,4 +1,5 @@
-import { filtersInstructions } from '#data/filters'
+import { makeFiltersInstructions } from '#data/filters'
+import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
   PageLayout,
@@ -6,12 +7,20 @@ import {
   useTranslation
 } from '@commercelayer/app-elements'
 import { useLocation } from 'wouter'
+import { useSearch } from 'wouter/use-browser-location'
 
 function Filters(): React.JSX.Element {
   const [, setLocation] = useLocation()
   const { t } = useTranslation()
+  const queryString = useSearch()
+  const params = new URLSearchParams(queryString)
+  const viewTitle = params.get('viewTitle') ?? undefined
+  const isPickingPage = viewTitle === presets.picking.viewTitle
+
   const { FiltersForm, adapters } = useResourceFilters({
-    instructions: filtersInstructions
+    instructions: makeFiltersInstructions({
+      hideFilterStatus: isPickingPage
+    })
   })
 
   return (

--- a/apps/shipments/src/pages/Home.tsx
+++ b/apps/shipments/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { filtersInstructions } from '#data/filters'
+import { makeFiltersInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -25,7 +25,7 @@ function Home(): React.JSX.Element {
   const { data: counters, isLoading: isLoadingCounters } = useListCounters()
 
   const { SearchWithNav, adapters } = useResourceFilters({
-    instructions: filtersInstructions
+    instructions: makeFiltersInstructions()
   })
 
   const getPresetUrl = useCallback(

--- a/apps/shipments/src/pages/ShipmentList.tsx
+++ b/apps/shipments/src/pages/ShipmentList.tsx
@@ -1,5 +1,6 @@
 import { ListItemShipment } from '#components/ListItemShipment'
-import { filtersInstructions } from '#data/filters'
+import { makeFiltersInstructions } from '#data/filters'
+import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
   EmptyState,
@@ -20,16 +21,23 @@ function ShipmentList(): React.JSX.Element {
   const { t } = useTranslation()
 
   const queryString = useSearch()
-  const { SearchWithNav, FilteredList, viewTitle } = useResourceFilters({
-    instructions: filtersInstructions
-  })
+  const params = new URLSearchParams(queryString)
+  const viewTitle = params.get('viewTitle') ?? undefined
+  const isPickingPage = viewTitle === presets.picking.viewTitle
   const isInViewPreset = viewTitle != null
+  const showSearchWithNav = isInViewPreset && !isPickingPage
+
+  const { SearchWithNav, FilteredList } = useResourceFilters({
+    instructions: makeFiltersInstructions({
+      hideFilterStatus: isPickingPage
+    })
+  })
 
   return (
     <PageLayout
       title={viewTitle ?? t('resources.shipments.name_other')}
       mode={mode}
-      gap={isInViewPreset ? undefined : 'only-top'}
+      gap={showSearchWithNav ? undefined : 'only-top'}
       navigationButton={{
         onClick: () => {
           setLocation(appRoutes.home.makePath({}))
@@ -48,8 +56,8 @@ function ShipmentList(): React.JSX.Element {
         onFilterClick={(queryString) => {
           setLocation(appRoutes.filters.makePath({}, queryString))
         }}
-        hideFiltersNav={isInViewPreset}
-        hideSearchBar={isInViewPreset}
+        hideFiltersNav={showSearchWithNav}
+        hideSearchBar={showSearchWithNav}
       />
 
       <Spacer bottom='14'>

--- a/apps/shipments/src/pages/ShipmentList.tsx
+++ b/apps/shipments/src/pages/ShipmentList.tsx
@@ -1,6 +1,5 @@
 import { ListItemShipment } from '#components/ListItemShipment'
 import { makeFiltersInstructions } from '#data/filters'
-import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
   EmptyState,
@@ -23,13 +22,11 @@ function ShipmentList(): React.JSX.Element {
   const queryString = useSearch()
   const params = new URLSearchParams(queryString)
   const viewTitle = params.get('viewTitle') ?? undefined
-  const isPickingPage = viewTitle === presets.picking.viewTitle
   const isInViewPreset = viewTitle != null
-  const showSearchWithNav = isInViewPreset && !isPickingPage
 
   const { SearchWithNav, FilteredList } = useResourceFilters({
     instructions: makeFiltersInstructions({
-      hideFilterStatus: isPickingPage
+      hideFilterStatus: isInViewPreset
     })
   })
 
@@ -37,7 +34,7 @@ function ShipmentList(): React.JSX.Element {
     <PageLayout
       title={viewTitle ?? t('resources.shipments.name_other')}
       mode={mode}
-      gap={showSearchWithNav ? undefined : 'only-top'}
+      gap='only-top'
       navigationButton={{
         onClick: () => {
           setLocation(appRoutes.home.makePath({}))
@@ -56,8 +53,6 @@ function ShipmentList(): React.JSX.Element {
         onFilterClick={(queryString) => {
           setLocation(appRoutes.filters.makePath({}, queryString))
         }}
-        hideFiltersNav={showSearchWithNav}
-        hideSearchBar={showSearchWithNav}
       />
 
       <Spacer bottom='14'>

--- a/apps/shipments/src/pages/ShipmentList.tsx
+++ b/apps/shipments/src/pages/ShipmentList.tsx
@@ -66,6 +66,7 @@ function ShipmentList(): React.JSX.Element {
                 'number',
                 'updated_at',
                 'status',
+                'reference',
                 'order',
                 'stock_location',
                 'stock_transfers',

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "@commercelayer/sdk": "^6.36.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.5.0",
+    "@commercelayer/app-elements": "5.5.1",
     "lodash-es": "^4.17.21",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -115,8 +115,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -197,8 +197,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
@@ -288,8 +288,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -370,8 +370,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.0.0)(typescript@5.8.2)
@@ -464,8 +464,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -549,8 +549,8 @@ importers:
   apps/my_sample_app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -634,8 +634,8 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -722,8 +722,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -807,8 +807,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -895,8 +895,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -980,8 +980,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1065,8 +1065,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1153,8 +1153,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1244,8 +1244,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1326,8 +1326,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -1411,8 +1411,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1493,8 +1493,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: 6.36.0
         version: 6.36.0
@@ -1599,8 +1599,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       '@commercelayer/sdk':
         specifier: ^6.36.0
         version: 6.36.0
@@ -1657,8 +1657,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.5.0
-        version: 5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
+        specifier: 5.5.1
+        version: 5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1825,8 +1825,8 @@ packages:
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
 
-  '@commercelayer/app-elements@5.5.0':
-    resolution: {integrity: sha512-1qPMxm8I1QSRTR96AsNBs5qJd4eBwG5nM3AgxkotWsRjlfI26ryFYEcVhvXW0ZN9GSygn6AAWyJ3de17Qvh+9w==}
+  '@commercelayer/app-elements@5.5.1':
+    resolution: {integrity: sha512-QEwY/f04XfzmPYBYtfQS3PwdQUd2471CCO9PXcqiWBNE50jMLZ3pz7cmjx781ZkfS7NoP2bcQ9/7S/p2ugTDMA==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -6240,7 +6240,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@commercelayer/app-elements@5.5.0(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))':
+  '@commercelayer/app-elements@5.5.1(@commercelayer/sdk@6.36.0)(query-string@8.2.0)(react-dom@19.0.0(react@19.0.0))(react-gtm-module@2.0.11)(react-hook-form@7.54.2(react@19.0.0))(react@19.0.0)(typescript@5.8.2)(wouter@3.6.0(react@19.0.0))':
     dependencies:
       '@commercelayer/js-auth': 6.7.1
       '@commercelayer/sdk': 6.36.0


### PR DESCRIPTION
Closes  commercelayer/issues-app#400

## What I did

- Updated app-elements
- Add filters in all listing pages (views: picking, packing, ready to ship, on hold). In these views, the filter status is hidden.
- Show reference (in available) in listing pages
- Auto-select first available package and hide unit of weight label in packing form

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8c34d361-0e6e-40de-8a6d-675661313144" />

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
