### PR TITLE
Show `approved` orders in subscription details

### DIFF
--- a/apps/subscriptions/src/components/SubscriptionOrders.tsx
+++ b/apps/subscriptions/src/components/SubscriptionOrders.tsx
@@ -11,8 +11,14 @@ import {
   useResourceList,
   withSkeletonTemplate
 } from '@commercelayer/app-elements'
-import type { OrderSubscription } from '@commercelayer/sdk'
+import type { Order, OrderSubscription } from '@commercelayer/sdk'
 import { useLocation } from 'wouter'
+
+export const allowedOrderStatuses: Array<Order['status']> = [
+  'pending',
+  'placed',
+  'approved'
+]
 
 interface Props {
   subscription: OrderSubscription
@@ -25,7 +31,7 @@ export const SubscriptionOrders = withSkeletonTemplate<Props>(
       query: {
         filters: {
           order_subscription_id_eq: subscription.id,
-          status_in: ['placed', 'pending']
+          status_in: allowedOrderStatuses
         },
         sort: ['-updated_at'],
         pageSize: 5

--- a/apps/subscriptions/src/pages/SubscriptionOrders.tsx
+++ b/apps/subscriptions/src/pages/SubscriptionOrders.tsx
@@ -1,3 +1,8 @@
+import { ListItemSubscriptionOrder } from '#components/ListItemSubscriptionOrder'
+import { allowedOrderStatuses } from '#components/SubscriptionOrders'
+import { appRoutes } from '#data/routes'
+import { useSubscriptionDetails } from '#hooks/useSubscriptionDetails'
+import { getSubscriptionTitle } from '#utils/getSubscriptionTitle'
 import {
   Button,
   EmptyState,
@@ -9,11 +14,6 @@ import {
   useTokenProvider
 } from '@commercelayer/app-elements'
 import { Link, useLocation, useRoute } from 'wouter'
-
-import { ListItemSubscriptionOrder } from '#components/ListItemSubscriptionOrder'
-import { appRoutes } from '#data/routes'
-import { useSubscriptionDetails } from '#hooks/useSubscriptionDetails'
-import { getSubscriptionTitle } from '#utils/getSubscriptionTitle'
 
 export function SubscriptionOrders(): React.JSX.Element {
   const { canUser } = useTokenProvider()
@@ -29,7 +29,7 @@ export function SubscriptionOrders(): React.JSX.Element {
     query: {
       filters: {
         order_subscription_id_eq: subscriptionId,
-        status_in: ['placed', 'pending']
+        status_in: allowedOrderStatuses
       },
       sort: ['-updated_at'],
       pageSize: 25


### PR DESCRIPTION
Closes commercelayer/issues-app#361

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

We now show show `approved` orders in subscription details page

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
