### PR TITLE
Allow to filter orders by country

### DIFF
--- a/apps/orders/src/data/filters.ts
+++ b/apps/orders/src/data/filters.ts
@@ -1,5 +1,5 @@
-import { t, type FiltersInstructions } from '@commercelayer/app-elements';
-import isEmpty from 'lodash-es/isEmpty';
+import { t, type FiltersInstructions } from '@commercelayer/app-elements'
+import isEmpty from 'lodash-es/isEmpty'
 
 export type CountryCodesFilterOptions = Array<{ label: string; value: string }>
 
@@ -10,245 +10,243 @@ export const makeInstructions = ({
   sortByAttribute?: 'placed_at' | 'created_at'
   countryCodes?: CountryCodesFilterOptions
 }): FiltersInstructions => [
-    {
-      label: t('resources.markets.name_other'),
-      type: 'options',
-      sdk: {
-        predicate: 'market_id_in'
-      },
-      render: {
-        component: 'inputResourceGroup',
-        props: {
-          fieldForLabel: 'name',
-          fieldForValue: 'id',
-          resource: 'markets',
-          searchBy: 'name_cont',
-          sortBy: { attribute: 'name', direction: 'asc' },
-          previewLimit: 5,
-          hideWhenSingleItem: true,
-          filters: {
-            disabled_at_null: true
+  {
+    label: t('apps.orders.attributes.status'),
+    type: 'options',
+    sdk: {
+      predicate: 'status_in',
+      defaultOptions: ['placed', 'approved', 'cancelled', 'editing']
+    },
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'multi',
+        options: [
+          {
+            value: 'pending',
+            label: t('resources.orders.attributes.status.pending'),
+            isHidden: true
+          },
+          {
+            value: 'placed',
+            label: t('resources.orders.attributes.status.placed')
+          },
+          {
+            value: 'approved',
+            label: t('resources.orders.attributes.status.approved')
+          },
+          {
+            value: 'cancelled',
+            label: t('resources.orders.attributes.status.cancelled')
+          },
+          {
+            value: 'editing',
+            label: t('resources.orders.attributes.status.editing')
           }
-        }
-      }
-    },
-    {
-      label: 'Countries',
-      type: 'options',
-      hidden: countryCodes == null || countryCodes.length === 0,
-      sdk: {
-        predicate: 'country_codes_in'
-      },
-      render: {
-        component: 'inputToggleButton',
-        props: {
-          mode: 'multi',
-          options: countryCodes ?? []
-        }
-      }
-    },
-
-    {
-      label: t('apps.orders.attributes.status'),
-      type: 'options',
-      sdk: {
-        predicate: 'status_in',
-        defaultOptions: ['placed', 'approved', 'cancelled', 'editing']
-      },
-      render: {
-        component: 'inputToggleButton',
-        props: {
-          mode: 'multi',
-          options: [
-            {
-              value: 'pending',
-              label: t('resources.orders.attributes.status.pending'),
-              isHidden: true
-            },
-            {
-              value: 'placed',
-              label: t('resources.orders.attributes.status.placed')
-            },
-            {
-              value: 'approved',
-              label: t('resources.orders.attributes.status.approved')
-            },
-            {
-              value: 'cancelled',
-              label: t('resources.orders.attributes.status.cancelled')
-            },
-            {
-              value: 'editing',
-              label: t('resources.orders.attributes.status.editing')
-            }
-          ]
-        }
-      }
-    },
-    {
-      label: t('apps.orders.attributes.payment_status'),
-      type: 'options',
-      sdk: {
-        predicate: 'payment_status_in'
-      },
-      render: {
-        component: 'inputToggleButton',
-        props: {
-          mode: 'multi',
-          options: [
-            {
-              value: 'authorized',
-              label: t('resources.orders.attributes.payment_status.authorized')
-            },
-            {
-              value: 'paid',
-              label: t('resources.orders.attributes.payment_status.paid')
-            },
-            {
-              value: 'voided',
-              label: t('resources.orders.attributes.payment_status.voided')
-            },
-            {
-              value: 'refunded',
-              label: t('resources.orders.attributes.payment_status.refunded')
-            },
-            {
-              value: 'partially_authorized',
-              label: t(
-                'resources.orders.attributes.payment_status.partially_authorized'
-              )
-            },
-            {
-              value: 'partially_refunded',
-              label: t(
-                'resources.orders.attributes.payment_status.partially_refunded'
-              )
-            },
-            {
-              value: 'free',
-              label: t('resources.orders.attributes.payment_status.free')
-            },
-            {
-              value: 'unpaid',
-              label: t('resources.orders.attributes.payment_status.unpaid')
-            }
-          ]
-        }
-      }
-    },
-    {
-      label: t('apps.orders.attributes.fulfillment_status'),
-      type: 'options',
-      sdk: {
-        predicate: 'fulfillment_status_in'
-      },
-      render: {
-        component: 'inputToggleButton',
-        props: {
-          mode: 'multi',
-          options: [
-            {
-              value: 'unfulfilled',
-              label: t(
-                'resources.orders.attributes.fulfillment_status.unfulfilled'
-              )
-            },
-            {
-              value: 'in_progress',
-              label: t(
-                'resources.orders.attributes.fulfillment_status.in_progress'
-              )
-            },
-            {
-              value: 'fulfilled',
-              label: t('resources.orders.attributes.fulfillment_status.fulfilled')
-            },
-            {
-              value: 'not_required',
-              label: t(
-                'resources.orders.attributes.fulfillment_status.not_required'
-              )
-            }
-          ]
-        }
-      }
-    },
-    {
-      label: t('apps.orders.tasks.archived'),
-      type: 'options',
-      sdk: {
-        predicate: 'archived',
-        parseFormValue: (value) =>
-          value === 'show' ? undefined : value === 'only'
-      },
-      hidden: true,
-      render: {
-        component: 'inputToggleButton',
-        props: {
-          mode: 'single',
-          options: [
-            { value: 'only', label: 'Only archived' },
-            { value: 'hide', label: 'Hide archived' },
-            { value: 'show', label: 'Show all, both archived and not' }
-          ]
-        }
-      }
-    },
-    {
-      label: t('common.time_range'),
-      type: 'timeRange',
-      sdk: {
-        predicate: sortByAttribute
-      },
-      render: {
-        component: 'dateRangePicker'
-      }
-    },
-    {
-      label: t('common.amount'),
-      type: 'currencyRange',
-      sdk: {
-        predicate: 'total_amount_cents'
-      },
-      render: {
-        component: 'inputCurrencyRange',
-        props: {
-          label: t('common.amount')
-        }
-      }
-    },
-    {
-      label: t('resources.tags.name_other'),
-      type: 'options',
-      sdk: {
-        predicate: 'tags_id_in'
-      },
-      render: {
-        component: 'inputResourceGroup',
-        props: {
-          fieldForLabel: 'name',
-          fieldForValue: 'id',
-          resource: 'tags',
-          searchBy: 'name_cont',
-          sortBy: { attribute: 'name', direction: 'asc' },
-          previewLimit: 5,
-          showCheckboxIcon: false
-        }
-      }
-    },
-
-    {
-      label: t('common.search'),
-      type: 'textSearch',
-      sdk: {
-        predicate: 'aggregated_details',
-        parseFormValue: parseTextSearchValue
-      },
-      render: {
-        component: 'searchBar'
+        ]
       }
     }
-  ]
+  },
+  {
+    label: t('apps.orders.attributes.payment_status'),
+    type: 'options',
+    sdk: {
+      predicate: 'payment_status_in'
+    },
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'multi',
+        options: [
+          {
+            value: 'authorized',
+            label: t('resources.orders.attributes.payment_status.authorized')
+          },
+          {
+            value: 'paid',
+            label: t('resources.orders.attributes.payment_status.paid')
+          },
+          {
+            value: 'voided',
+            label: t('resources.orders.attributes.payment_status.voided')
+          },
+          {
+            value: 'refunded',
+            label: t('resources.orders.attributes.payment_status.refunded')
+          },
+          {
+            value: 'partially_authorized',
+            label: t(
+              'resources.orders.attributes.payment_status.partially_authorized'
+            )
+          },
+          {
+            value: 'partially_refunded',
+            label: t(
+              'resources.orders.attributes.payment_status.partially_refunded'
+            )
+          },
+          {
+            value: 'free',
+            label: t('resources.orders.attributes.payment_status.free')
+          },
+          {
+            value: 'unpaid',
+            label: t('resources.orders.attributes.payment_status.unpaid')
+          }
+        ]
+      }
+    }
+  },
+  {
+    label: t('apps.orders.attributes.fulfillment_status'),
+    type: 'options',
+    sdk: {
+      predicate: 'fulfillment_status_in'
+    },
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'multi',
+        options: [
+          {
+            value: 'unfulfilled',
+            label: t(
+              'resources.orders.attributes.fulfillment_status.unfulfilled'
+            )
+          },
+          {
+            value: 'in_progress',
+            label: t(
+              'resources.orders.attributes.fulfillment_status.in_progress'
+            )
+          },
+          {
+            value: 'fulfilled',
+            label: t('resources.orders.attributes.fulfillment_status.fulfilled')
+          },
+          {
+            value: 'not_required',
+            label: t(
+              'resources.orders.attributes.fulfillment_status.not_required'
+            )
+          }
+        ]
+      }
+    }
+  },
+  {
+    label: t('resources.markets.name_other'),
+    type: 'options',
+    sdk: {
+      predicate: 'market_id_in'
+    },
+    render: {
+      component: 'inputResourceGroup',
+      props: {
+        fieldForLabel: 'name',
+        fieldForValue: 'id',
+        resource: 'markets',
+        searchBy: 'name_cont',
+        sortBy: { attribute: 'name', direction: 'asc' },
+        previewLimit: 5,
+        hideWhenSingleItem: true,
+        filters: {
+          disabled_at_null: true
+        }
+      }
+    }
+  },
+  {
+    label: 'Countries',
+    type: 'options',
+    hidden: countryCodes == null || countryCodes.length === 0,
+    sdk: {
+      predicate: 'country_codes_in'
+    },
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'multi',
+        options: countryCodes ?? []
+      }
+    }
+  },
+  {
+    label: t('apps.orders.tasks.archived'),
+    type: 'options',
+    sdk: {
+      predicate: 'archived',
+      parseFormValue: (value) =>
+        value === 'show' ? undefined : value === 'only'
+    },
+    hidden: true,
+    render: {
+      component: 'inputToggleButton',
+      props: {
+        mode: 'single',
+        options: [
+          { value: 'only', label: 'Only archived' },
+          { value: 'hide', label: 'Hide archived' },
+          { value: 'show', label: 'Show all, both archived and not' }
+        ]
+      }
+    }
+  },
+  {
+    label: t('common.time_range'),
+    type: 'timeRange',
+    sdk: {
+      predicate: sortByAttribute
+    },
+    render: {
+      component: 'dateRangePicker'
+    }
+  },
+  {
+    label: t('common.amount'),
+    type: 'currencyRange',
+    sdk: {
+      predicate: 'total_amount_cents'
+    },
+    render: {
+      component: 'inputCurrencyRange',
+      props: {
+        label: t('common.amount')
+      }
+    }
+  },
+  {
+    label: t('resources.tags.name_other'),
+    type: 'options',
+    sdk: {
+      predicate: 'tags_id_in'
+    },
+    render: {
+      component: 'inputResourceGroup',
+      props: {
+        fieldForLabel: 'name',
+        fieldForValue: 'id',
+        resource: 'tags',
+        searchBy: 'name_cont',
+        sortBy: { attribute: 'name', direction: 'asc' },
+        previewLimit: 5,
+        showCheckboxIcon: false
+      }
+    }
+  },
+  {
+    label: t('common.search'),
+    type: 'textSearch',
+    sdk: {
+      predicate: 'aggregated_details',
+      parseFormValue: parseTextSearchValue
+    },
+    render: {
+      component: 'searchBar'
+    }
+  }
+]
 
 export const makeCartsInstructions = (): FiltersInstructions => [
   {

--- a/apps/orders/src/data/filters.ts
+++ b/apps/orders/src/data/filters.ts
@@ -1,234 +1,254 @@
-import { t, type FiltersInstructions } from '@commercelayer/app-elements'
-import isEmpty from 'lodash-es/isEmpty'
+import { t, type FiltersInstructions } from '@commercelayer/app-elements';
+import isEmpty from 'lodash-es/isEmpty';
+
+export type CountryCodesFilterOptions = Array<{ label: string; value: string }>
 
 export const makeInstructions = ({
-  sortByAttribute = 'placed_at'
+  sortByAttribute = 'placed_at',
+  countryCodes
 }: {
   sortByAttribute?: 'placed_at' | 'created_at'
+  countryCodes?: CountryCodesFilterOptions
 }): FiltersInstructions => [
-  {
-    label: t('resources.markets.name_other'),
-    type: 'options',
-    sdk: {
-      predicate: 'market_id_in'
-    },
-    render: {
-      component: 'inputResourceGroup',
-      props: {
-        fieldForLabel: 'name',
-        fieldForValue: 'id',
-        resource: 'markets',
-        searchBy: 'name_cont',
-        sortBy: { attribute: 'name', direction: 'asc' },
-        previewLimit: 5,
-        hideWhenSingleItem: true,
-        filters: {
-          disabled_at_null: true
+    {
+      label: t('resources.markets.name_other'),
+      type: 'options',
+      sdk: {
+        predicate: 'market_id_in'
+      },
+      render: {
+        component: 'inputResourceGroup',
+        props: {
+          fieldForLabel: 'name',
+          fieldForValue: 'id',
+          resource: 'markets',
+          searchBy: 'name_cont',
+          sortBy: { attribute: 'name', direction: 'asc' },
+          previewLimit: 5,
+          hideWhenSingleItem: true,
+          filters: {
+            disabled_at_null: true
+          }
         }
       }
-    }
-  },
-  {
-    label: t('apps.orders.attributes.status'),
-    type: 'options',
-    sdk: {
-      predicate: 'status_in',
-      defaultOptions: ['placed', 'approved', 'cancelled', 'editing']
     },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: [
-          {
-            value: 'pending',
-            label: t('resources.orders.attributes.status.pending'),
-            isHidden: true
-          },
-          {
-            value: 'placed',
-            label: t('resources.orders.attributes.status.placed')
-          },
-          {
-            value: 'approved',
-            label: t('resources.orders.attributes.status.approved')
-          },
-          {
-            value: 'cancelled',
-            label: t('resources.orders.attributes.status.cancelled')
-          },
-          {
-            value: 'editing',
-            label: t('resources.orders.attributes.status.editing')
-          }
-        ]
+    {
+      label: 'Countries',
+      type: 'options',
+      hidden: countryCodes == null || countryCodes.length === 0,
+      sdk: {
+        predicate: 'country_codes_in'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: countryCodes ?? []
+        }
       }
-    }
-  },
-  {
-    label: t('apps.orders.attributes.payment_status'),
-    type: 'options',
-    sdk: {
-      predicate: 'payment_status_in'
     },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: [
-          {
-            value: 'authorized',
-            label: t('resources.orders.attributes.payment_status.authorized')
-          },
-          {
-            value: 'paid',
-            label: t('resources.orders.attributes.payment_status.paid')
-          },
-          {
-            value: 'voided',
-            label: t('resources.orders.attributes.payment_status.voided')
-          },
-          {
-            value: 'refunded',
-            label: t('resources.orders.attributes.payment_status.refunded')
-          },
-          {
-            value: 'partially_authorized',
-            label: t(
-              'resources.orders.attributes.payment_status.partially_authorized'
-            )
-          },
-          {
-            value: 'partially_refunded',
-            label: t(
-              'resources.orders.attributes.payment_status.partially_refunded'
-            )
-          },
-          {
-            value: 'free',
-            label: t('resources.orders.attributes.payment_status.free')
-          },
-          {
-            value: 'unpaid',
-            label: t('resources.orders.attributes.payment_status.unpaid')
-          }
-        ]
-      }
-    }
-  },
-  {
-    label: t('apps.orders.attributes.fulfillment_status'),
-    type: 'options',
-    sdk: {
-      predicate: 'fulfillment_status_in'
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: [
-          {
-            value: 'unfulfilled',
-            label: t(
-              'resources.orders.attributes.fulfillment_status.unfulfilled'
-            )
-          },
-          {
-            value: 'in_progress',
-            label: t(
-              'resources.orders.attributes.fulfillment_status.in_progress'
-            )
-          },
-          {
-            value: 'fulfilled',
-            label: t('resources.orders.attributes.fulfillment_status.fulfilled')
-          },
-          {
-            value: 'not_required',
-            label: t(
-              'resources.orders.attributes.fulfillment_status.not_required'
-            )
-          }
-        ]
-      }
-    }
-  },
-  {
-    label: t('apps.orders.tasks.archived'),
-    type: 'options',
-    sdk: {
-      predicate: 'archived',
-      parseFormValue: (value) =>
-        value === 'show' ? undefined : value === 'only'
-    },
-    hidden: true,
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'single',
-        options: [
-          { value: 'only', label: 'Only archived' },
-          { value: 'hide', label: 'Hide archived' },
-          { value: 'show', label: 'Show all, both archived and not' }
-        ]
-      }
-    }
-  },
-  {
-    label: t('common.time_range'),
-    type: 'timeRange',
-    sdk: {
-      predicate: sortByAttribute
-    },
-    render: {
-      component: 'dateRangePicker'
-    }
-  },
-  {
-    label: t('common.amount'),
-    type: 'currencyRange',
-    sdk: {
-      predicate: 'total_amount_cents'
-    },
-    render: {
-      component: 'inputCurrencyRange',
-      props: {
-        label: t('common.amount')
-      }
-    }
-  },
-  {
-    label: t('resources.tags.name_other'),
-    type: 'options',
-    sdk: {
-      predicate: 'tags_id_in'
-    },
-    render: {
-      component: 'inputResourceGroup',
-      props: {
-        fieldForLabel: 'name',
-        fieldForValue: 'id',
-        resource: 'tags',
-        searchBy: 'name_cont',
-        sortBy: { attribute: 'name', direction: 'asc' },
-        previewLimit: 5,
-        showCheckboxIcon: false
-      }
-    }
-  },
 
-  {
-    label: t('common.search'),
-    type: 'textSearch',
-    sdk: {
-      predicate: 'aggregated_details',
-      parseFormValue: parseTextSearchValue
+    {
+      label: t('apps.orders.attributes.status'),
+      type: 'options',
+      sdk: {
+        predicate: 'status_in',
+        defaultOptions: ['placed', 'approved', 'cancelled', 'editing']
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: [
+            {
+              value: 'pending',
+              label: t('resources.orders.attributes.status.pending'),
+              isHidden: true
+            },
+            {
+              value: 'placed',
+              label: t('resources.orders.attributes.status.placed')
+            },
+            {
+              value: 'approved',
+              label: t('resources.orders.attributes.status.approved')
+            },
+            {
+              value: 'cancelled',
+              label: t('resources.orders.attributes.status.cancelled')
+            },
+            {
+              value: 'editing',
+              label: t('resources.orders.attributes.status.editing')
+            }
+          ]
+        }
+      }
     },
-    render: {
-      component: 'searchBar'
+    {
+      label: t('apps.orders.attributes.payment_status'),
+      type: 'options',
+      sdk: {
+        predicate: 'payment_status_in'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: [
+            {
+              value: 'authorized',
+              label: t('resources.orders.attributes.payment_status.authorized')
+            },
+            {
+              value: 'paid',
+              label: t('resources.orders.attributes.payment_status.paid')
+            },
+            {
+              value: 'voided',
+              label: t('resources.orders.attributes.payment_status.voided')
+            },
+            {
+              value: 'refunded',
+              label: t('resources.orders.attributes.payment_status.refunded')
+            },
+            {
+              value: 'partially_authorized',
+              label: t(
+                'resources.orders.attributes.payment_status.partially_authorized'
+              )
+            },
+            {
+              value: 'partially_refunded',
+              label: t(
+                'resources.orders.attributes.payment_status.partially_refunded'
+              )
+            },
+            {
+              value: 'free',
+              label: t('resources.orders.attributes.payment_status.free')
+            },
+            {
+              value: 'unpaid',
+              label: t('resources.orders.attributes.payment_status.unpaid')
+            }
+          ]
+        }
+      }
+    },
+    {
+      label: t('apps.orders.attributes.fulfillment_status'),
+      type: 'options',
+      sdk: {
+        predicate: 'fulfillment_status_in'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: [
+            {
+              value: 'unfulfilled',
+              label: t(
+                'resources.orders.attributes.fulfillment_status.unfulfilled'
+              )
+            },
+            {
+              value: 'in_progress',
+              label: t(
+                'resources.orders.attributes.fulfillment_status.in_progress'
+              )
+            },
+            {
+              value: 'fulfilled',
+              label: t('resources.orders.attributes.fulfillment_status.fulfilled')
+            },
+            {
+              value: 'not_required',
+              label: t(
+                'resources.orders.attributes.fulfillment_status.not_required'
+              )
+            }
+          ]
+        }
+      }
+    },
+    {
+      label: t('apps.orders.tasks.archived'),
+      type: 'options',
+      sdk: {
+        predicate: 'archived',
+        parseFormValue: (value) =>
+          value === 'show' ? undefined : value === 'only'
+      },
+      hidden: true,
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'single',
+          options: [
+            { value: 'only', label: 'Only archived' },
+            { value: 'hide', label: 'Hide archived' },
+            { value: 'show', label: 'Show all, both archived and not' }
+          ]
+        }
+      }
+    },
+    {
+      label: t('common.time_range'),
+      type: 'timeRange',
+      sdk: {
+        predicate: sortByAttribute
+      },
+      render: {
+        component: 'dateRangePicker'
+      }
+    },
+    {
+      label: t('common.amount'),
+      type: 'currencyRange',
+      sdk: {
+        predicate: 'total_amount_cents'
+      },
+      render: {
+        component: 'inputCurrencyRange',
+        props: {
+          label: t('common.amount')
+        }
+      }
+    },
+    {
+      label: t('resources.tags.name_other'),
+      type: 'options',
+      sdk: {
+        predicate: 'tags_id_in'
+      },
+      render: {
+        component: 'inputResourceGroup',
+        props: {
+          fieldForLabel: 'name',
+          fieldForValue: 'id',
+          resource: 'tags',
+          searchBy: 'name_cont',
+          sortBy: { attribute: 'name', direction: 'asc' },
+          previewLimit: 5,
+          showCheckboxIcon: false
+        }
+      }
+    },
+
+    {
+      label: t('common.search'),
+      type: 'textSearch',
+      sdk: {
+        predicate: 'aggregated_details',
+        parseFormValue: parseTextSearchValue
+      },
+      render: {
+        component: 'searchBar'
+      }
     }
-  }
-]
+  ]
 
 export const makeCartsInstructions = (): FiltersInstructions => [
   {

--- a/apps/orders/src/metricsApi/useCountryCodes.ts
+++ b/apps/orders/src/metricsApi/useCountryCodes.ts
@@ -1,0 +1,101 @@
+import { type CountryCodesFilterOptions } from '#data/filters'
+import { useTokenProvider } from '@commercelayer/app-elements'
+import useSWR from 'swr'
+import { metricsApiFetcher } from './fetcher'
+
+interface MetricsApiBreakdownByCountryResponse {
+  'order.country_code'?: Array<{
+    label: string // country code
+    value: string // orders count
+  }>
+}
+
+export function useCountryCodes(): {
+  countryCodes: Array<{ label: string; value: string }>
+  isLoading: boolean
+} {
+  const {
+    settings: { accessToken, organizationSlug, domain }
+  } = useTokenProvider()
+
+  const { data, isLoading } = useSWR(
+    {
+      domain,
+      slug: organizationSlug,
+      accessToken
+    },
+    fetchCountryForFilter,
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false
+    }
+  )
+
+  return {
+    countryCodes: data ?? [],
+    isLoading
+  }
+}
+
+async function fetchCountryDictionary(): Promise<
+  Array<{
+    value: string
+    label: string
+  }>
+> {
+  const res = await fetch(
+    'https://data.commercelayer.app/assets/lists/countries.json'
+  )
+  if (!res.ok) throw new Error('Failed to fetch countries')
+  return await res.json()
+}
+
+async function fetchCountryForFilter({
+  domain,
+  slug,
+  accessToken
+}: {
+  domain: string
+  slug: string
+  accessToken: string
+}): Promise<CountryCodesFilterOptions> {
+  return await Promise.allSettled([
+    metricsApiFetcher<MetricsApiBreakdownByCountryResponse>({
+      endpoint: '/orders/breakdown',
+      domain,
+      slug,
+      accessToken,
+      body: {
+        breakdown: {
+          by: 'order.country_code',
+          field: 'order.id',
+          operator: 'value_count',
+          sort: 'desc',
+          limit: 100
+        }
+      }
+    }),
+    fetchCountryDictionary()
+  ]).then(([responseMetrics, responseAllCountries]) => {
+    if (responseMetrics.status !== 'fulfilled') {
+      return []
+    }
+    const allCountries =
+      responseAllCountries.status === 'fulfilled'
+        ? responseAllCountries.value
+        : []
+    const normalizedOptions = responseMetrics.value.data[
+      'order.country_code'
+    ]?.map((metricsItem) => {
+      const countryCode = metricsItem.label
+      return {
+        value: countryCode,
+        label:
+          allCountries.find((country) => country.value === countryCode)
+            ?.label ?? countryCode.toUpperCase()
+      }
+    })
+    return normalizedOptions ?? []
+  })
+}

--- a/apps/orders/src/metricsApi/useCountryCodes.ts
+++ b/apps/orders/src/metricsApi/useCountryCodes.ts
@@ -28,7 +28,8 @@ export function useCountryCodes(): {
     {
       revalidateIfStale: false,
       revalidateOnFocus: false,
-      revalidateOnReconnect: false
+      revalidateOnReconnect: false,
+      suspense: true
     }
   )
 

--- a/apps/orders/src/pages/Filters.tsx
+++ b/apps/orders/src/pages/Filters.tsx
@@ -1,8 +1,4 @@
-import {
-  type CountryCodesFilterOptions,
-  makeCartsInstructions,
-  makeInstructions
-} from '#data/filters'
+import { makeCartsInstructions, makeInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -15,9 +11,8 @@ import { useCountryCodes } from 'src/metricsApi/useCountryCodes'
 import { useLocation } from 'wouter'
 import { useSearch } from 'wouter/use-browser-location'
 
-const Filters: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
-  countryCodes
-}) => {
+const Filters: FC = () => {
+  const { countryCodes } = useCountryCodes()
   const [, setLocation] = useLocation()
   const { t } = useTranslation()
 
@@ -67,14 +62,4 @@ const Filters: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
   )
 }
 
-const FiltersAsyncWrapper: FC = () => {
-  const { countryCodes, isLoading } = useCountryCodes()
-
-  if (isLoading) {
-    return null
-  }
-
-  return <Filters countryCodes={countryCodes} />
-}
-
-export default FiltersAsyncWrapper
+export default Filters

--- a/apps/orders/src/pages/Filters.tsx
+++ b/apps/orders/src/pages/Filters.tsx
@@ -1,4 +1,8 @@
-import { makeCartsInstructions, makeInstructions } from '#data/filters'
+import {
+  type CountryCodesFilterOptions,
+  makeCartsInstructions,
+  makeInstructions
+} from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -6,10 +10,14 @@ import {
   useResourceFilters,
   useTranslation
 } from '@commercelayer/app-elements'
+import type { FC } from 'react'
+import { useCountryCodes } from 'src/metricsApi/useCountryCodes'
 import { useLocation } from 'wouter'
 import { useSearch } from 'wouter/use-browser-location'
 
-function Filters(): React.JSX.Element {
+const Filters: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
+  countryCodes
+}) => {
   const [, setLocation] = useLocation()
   const { t } = useTranslation()
 
@@ -21,7 +29,9 @@ function Filters(): React.JSX.Element {
   const { FiltersForm, adapters } = useResourceFilters({
     instructions: isPendingOrdersList
       ? makeCartsInstructions()
-      : makeInstructions({})
+      : makeInstructions({
+        countryCodes
+      })
   })
 
   const searchParams = new URLSearchParams(location.search)
@@ -43,7 +53,7 @@ function Filters(): React.JSX.Element {
         },
         label: searchParams.has('viewTitle')
           ? // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
-            (searchParams.get('viewTitle') as string)
+          (searchParams.get('viewTitle') as string)
           : t('resources.orders.name_other'),
         icon: 'arrowLeft'
       }}
@@ -57,4 +67,14 @@ function Filters(): React.JSX.Element {
   )
 }
 
-export default Filters
+const FiltersAsyncWrapper: FC = () => {
+  const { countryCodes, isLoading } = useCountryCodes()
+
+  if (isLoading) {
+    return null
+  }
+
+  return <Filters countryCodes={countryCodes} />
+}
+
+export default FiltersAsyncWrapper

--- a/apps/orders/src/pages/Filters.tsx
+++ b/apps/orders/src/pages/Filters.tsx
@@ -30,8 +30,8 @@ const Filters: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
     instructions: isPendingOrdersList
       ? makeCartsInstructions()
       : makeInstructions({
-        countryCodes
-      })
+          countryCodes
+        })
   })
 
   const searchParams = new URLSearchParams(location.search)
@@ -53,7 +53,7 @@ const Filters: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
         },
         label: searchParams.has('viewTitle')
           ? // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
-          (searchParams.get('viewTitle') as string)
+            (searchParams.get('viewTitle') as string)
           : t('resources.orders.name_other'),
         icon: 'arrowLeft'
       }}

--- a/apps/orders/src/pages/OrderList.tsx
+++ b/apps/orders/src/pages/OrderList.tsx
@@ -1,6 +1,10 @@
 import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemOrder } from '#components/ListItemOrder'
-import { makeCartsInstructions, makeInstructions } from '#data/filters'
+import {
+  makeCartsInstructions,
+  makeInstructions,
+  type CountryCodesFilterOptions
+} from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -10,10 +14,14 @@ import {
   useTokenProvider,
   useTranslation
 } from '@commercelayer/app-elements'
+import { type FC } from 'react'
+import { useCountryCodes } from 'src/metricsApi/useCountryCodes'
 import { useLocation } from 'wouter'
 import { navigate, useSearch } from 'wouter/use-browser-location'
 
-function OrderList(): React.JSX.Element {
+const OrderList: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
+  countryCodes
+}) => {
   const {
     settings: { mode }
   } = useTokenProvider()
@@ -30,7 +38,8 @@ function OrderList(): React.JSX.Element {
       instructions: isPendingOrdersList
         ? makeCartsInstructions()
         : makeInstructions({
-            sortByAttribute: 'placed_at'
+            sortByAttribute: 'placed_at',
+            countryCodes
           })
     })
 
@@ -99,4 +108,14 @@ function OrderList(): React.JSX.Element {
   )
 }
 
-export default OrderList
+const OrderListAsyncWrapper: FC = () => {
+  const { countryCodes, isLoading } = useCountryCodes()
+
+  if (isLoading) {
+    return null
+  }
+
+  return <OrderList countryCodes={countryCodes} />
+}
+
+export default OrderListAsyncWrapper

--- a/apps/orders/src/pages/OrderList.tsx
+++ b/apps/orders/src/pages/OrderList.tsx
@@ -1,10 +1,6 @@
 import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemOrder } from '#components/ListItemOrder'
-import {
-  makeCartsInstructions,
-  makeInstructions,
-  type CountryCodesFilterOptions
-} from '#data/filters'
+import { makeCartsInstructions, makeInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -19,13 +15,12 @@ import { useCountryCodes } from 'src/metricsApi/useCountryCodes'
 import { useLocation } from 'wouter'
 import { navigate, useSearch } from 'wouter/use-browser-location'
 
-const OrderList: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
-  countryCodes
-}) => {
+const OrderList: FC = () => {
   const {
     settings: { mode }
   } = useTokenProvider()
   const { t } = useTranslation()
+  const { countryCodes } = useCountryCodes()
   const queryString = useSearch()
   const [, setLocation] = useLocation()
 
@@ -108,14 +103,4 @@ const OrderList: FC<{ countryCodes?: CountryCodesFilterOptions }> = ({
   )
 }
 
-const OrderListAsyncWrapper: FC = () => {
-  const { countryCodes, isLoading } = useCountryCodes()
-
-  if (isLoading) {
-    return null
-  }
-
-  return <OrderList countryCodes={countryCodes} />
-}
-
-export default OrderListAsyncWrapper
+export default OrderList


### PR DESCRIPTION
Closes  commercelayer/issues-app#180

## What I did

I've added the possibility to filter orders by country code (multi-options).

<img width="530" alt="image" src="https://github.com/user-attachments/assets/63e67cc7-8df5-46c9-af18-c59c9722d3da" />


The list of all country codes is fetched using metrics api and then passed to the filters components as an array of value/label.
This approach requires to defer the rendering of listing and filters page only after the countries have been fetched, but since this request is cached and performed only the first time, the delay is unnoticeable.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
