### PR TITLE
Add new filters to orders export

### DIFF
--- a/apps/exports/src/components/Form/Filters/Orders.tsx
+++ b/apps/exports/src/components/Form/Filters/Orders.tsx
@@ -86,6 +86,98 @@ export function Orders({ onChange }: Props): React.JSX.Element | null {
         />
       </Spacer>
 
+      <Spacer bottom='6'>
+        <InputSelect
+          label='Payment status'
+          initialValues={[
+            {
+              value: 'authorized',
+              label: 'Authorized'
+            },
+            {
+              value: 'paid',
+              label: 'Paid'
+            },
+            {
+              value: 'voided',
+              label: 'Voided'
+            },
+            {
+              value: 'refunded',
+              label: 'Refunded'
+            },
+            {
+              value: 'partially_paid',
+              label: 'Partially paid'
+            },
+            {
+              value: 'partially_voided',
+              label: 'Partially voided'
+            },
+            {
+              value: 'partially_authorized',
+              label: 'Partially authorized'
+            },
+            {
+              value: 'partially_refunded',
+              label: 'Partially refunded'
+            },
+            {
+              value: 'free',
+              label: 'Free'
+            },
+            {
+              value: 'unpaid',
+              label: 'Unpaid'
+            }
+          ]}
+          isMulti
+          onSelect={(values) => {
+            updateFilters('payment_status_in', flatSelectValues(values))
+          }}
+        />
+      </Spacer>
+
+      <Spacer bottom='6'>
+        <InputSelect
+          label='Fulfillment status'
+          initialValues={[
+            {
+              value: 'unfulfilled',
+              label: 'Unfulfilled'
+            },
+            {
+              value: 'in_progress',
+              label: 'In progress'
+            },
+            {
+              value: 'fulfilled',
+              label: 'Fulfilled'
+            },
+            {
+              value: 'not_required',
+              label: 'Not required'
+            }
+          ]}
+          isMulti
+          onSelect={(values) => {
+            updateFilters('fulfillment_status_in', flatSelectValues(values))
+          }}
+        />
+      </Spacer>
+
+      <Spacer bottom='6'>
+        <ResourceFinder
+          label='Tags'
+          resourceType='tags'
+          isMulti
+          onSelect={(values) => {
+            updateFilters('tags_id_in', flatSelectValues(values))
+          }}
+          sdkClient={sdkClient}
+        />
+      </Spacer>
+
       <InputDateRange
         label='Placed date range'
         value={[

--- a/apps/exports/src/components/Form/ResourceFinder/index.tsx
+++ b/apps/exports/src/components/Form/ResourceFinder/index.tsx
@@ -8,7 +8,7 @@ import { type PossibleSelectValue } from '@commercelayer/app-elements/dist/ui/fo
 import { useEffect, useState } from 'react'
 import { fetchInitialResources, fetchResourcesByHint } from './utils'
 
-interface Props extends SearchParams<SearchableResource> {
+interface Props<Res extends SearchableResource> extends SearchParams<Res> {
   /**
    * Text to show above the input
    */
@@ -27,7 +27,7 @@ interface Props extends SearchParams<SearchableResource> {
   onSelect: (value: PossibleSelectValue) => void
 }
 
-export function ResourceFinder({
+export function ResourceFinder<Res extends SearchableResource>({
   label,
   placeholder = 'Type to search or select from the list...',
   resourceType,
@@ -37,7 +37,7 @@ export function ResourceFinder({
   fields,
   fieldForValue,
   fieldForLabel
-}: Props): React.JSX.Element {
+}: Props<Res>): React.JSX.Element {
   const [isLoading, setIsLoading] = useState(true)
   const [initialValues, setInitialValues] = useState<InputSelectValue[]>([])
   useEffect(() => {
@@ -57,7 +57,6 @@ export function ResourceFinder({
         setIsLoading(false)
       })
   }, [resourceType])
-
   return (
     <div>
       <Label gap>{label}</Label>

--- a/apps/exports/src/components/Form/ResourceFinder/utils.ts
+++ b/apps/exports/src/components/Form/ResourceFinder/utils.ts
@@ -12,6 +12,7 @@ export type SearchableResource =
   | 'price_lists'
   | 'shipping_categories'
   | 'stock_locations'
+  | 'tags'
 
 export interface SearchParams<Res extends SearchableResource> {
   /**
@@ -40,18 +41,18 @@ type ListResource<TResource extends SearchableResource> = Awaited<
   ReturnType<CommerceLayerClient[TResource]['list']>
 >
 
-export const fetchResourcesByHint = async ({
+export const fetchResourcesByHint = async <Res extends SearchableResource>({
   sdkClient,
   hint,
   resourceType,
   fields = ['name', 'id'],
   fieldForValue,
   fieldForLabel = 'name'
-}: SearchParams<SearchableResource> & {
+}: SearchParams<Res> & {
   hint: string
 }): Promise<InputSelectValue[]> => {
   const fetchedResources = await sdkClient[resourceType].list({
-    fields,
+    fields: fields as QueryArrayFields<Resource>,
     filters: {
       [`${fieldForLabel}_cont`]: hint
     },
@@ -64,15 +65,15 @@ export const fetchResourcesByHint = async ({
   })
 }
 
-export const fetchInitialResources = async ({
+export const fetchInitialResources = async <Res extends SearchableResource>({
   sdkClient,
   resourceType,
   fields = ['name', 'id'],
   fieldForValue,
   fieldForLabel
-}: SearchParams<SearchableResource>): Promise<InputSelectValue[]> => {
+}: SearchParams<Res>): Promise<InputSelectValue[]> => {
   const fetchedResources = await sdkClient[resourceType].list({
-    fields,
+    fields: fields as QueryArrayFields<Resource>,
     pageSize: 25
   })
   return adaptApiToSuggestions({

--- a/apps/exports/src/components/Form/types.d.ts
+++ b/apps/exports/src/components/Form/types.d.ts
@@ -12,6 +12,9 @@ declare module 'AppForm' {
   type OrdersField =
     | 'market_id_in'
     | 'status_in'
+    | 'payment_status_in'
+    | 'fulfillment_status_in'
+    | 'tags_id_in'
     | 'placed_at_gteq'
     | 'placed_at_lteq'
 

--- a/apps/exports/src/data/relationships.ts
+++ b/apps/exports/src/data/relationships.ts
@@ -3,7 +3,7 @@ import { type ResourceWithRelationship } from 'App'
 export const exportRelationships: Record<ResourceWithRelationship, string[]> = {
   bundles: ['sku_list', 'sku_list_items', 'tags'],
   customer_subscriptions: ['customer'],
-  customers: ['customer_subscriptions', 'tags'],
+  customers: ['customer_subscriptions', 'orders', 'tags'],
   coupons: ['promotion_rule.promotion'],
   in_stock_subscriptions: ['customer', 'market', 'sku'],
   orders: [


### PR DESCRIPTION
Closes commercelayer/issues-app#395
Closes commercelayer/issues-app#407

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've added the following filters to orders export:
- payment status
- fulfilment status
- tags

Adding the tags filter highlighted an issue with the type definitions of the ResourceFinder component, which weren't properly working with generics. I resolved it by introducing generic interfaces to both the React component and its related utilities.

I've also added the `orders` include in the customers export.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
