### PR TITLE
Enable custom fields subset for orders export

### DIFF
--- a/apps/exports/src/components/Form/index.tsx
+++ b/apps/exports/src/components/Form/index.tsx
@@ -1,17 +1,18 @@
 import { Filters } from '#components/Form/Filters'
 import { resourcesWithFilters } from '#components/Form/Filters/index'
 import { InputCode } from '#components/Form/Filters/InputCode'
+import { customFieldsSubset } from '#data/fields'
 import { showResourceNiceName } from '#data/resources'
 import {
   Button,
   HookedForm,
-  HookedInputSimpleSelect,
-  HookedInputSwitch,
-  ListItem,
-  Section,
+  HookedInputCheckbox,
+  HookedInputSelect,
+  Icon,
   Spacer,
   Tab,
-  Tabs
+  Tabs,
+  Tooltip
 } from '@commercelayer/app-elements'
 import { type AllowedResourceType } from 'App'
 import { type ExportFormValues } from 'AppForm'
@@ -66,42 +67,60 @@ export function Form({
           </Tab>
         </Tabs>
       </Spacer>
-      <Spacer bottom='14'>
+      <Spacer bottom='6'>
         <RelationshipSelector resourceType={resourceType} />
       </Spacer>
 
+      <Spacer bottom='6'>
+        <HookedInputSelect
+          label='Format'
+          name='format'
+          initialValues={[
+            { label: 'JSON', value: 'json' },
+            {
+              label: 'CSV',
+              value: 'csv'
+            }
+          ]}
+        />
+      </Spacer>
+
+      <Spacer bottom='2'>
+        {customFieldsSubset[resourceType] != null && (
+          <HookedInputCheckbox name='useCustomFields'>
+            <div
+              style={{
+                display: 'flex',
+                gap: '6px',
+                alignItems: 'center'
+              }}
+            >
+              Simple format
+              <Tooltip
+                label={<Icon name='info' />}
+                content='Export a predefined selection of key columns for easier use.'
+              />
+            </div>
+          </HookedInputCheckbox>
+        )}
+      </Spacer>
+
       <Spacer bottom='14'>
-        <Section title='More options' titleSize='small'>
-          <ListItem>
-            <HookedInputSwitch
-              id='toggle-cleanup'
-              inline
-              label='Dry data'
-              hint={{
-                text: 'Enable this flag to make the data importable.'
-              }}
-              name='dryData'
+        <HookedInputCheckbox name='dryData'>
+          <div
+            style={{
+              display: 'flex',
+              gap: '6px',
+              alignItems: 'center'
+            }}
+          >
+            Importable
+            <Tooltip
+              label={<Icon name='info' />}
+              content='Skip IDs, timestamps, and blanks to allow re-import.'
             />
-          </ListItem>
-          <ListItem>
-            <HookedInputSimpleSelect
-              id='format'
-              label='Format'
-              hint={{
-                text: 'Select the format of the exported data.'
-              }}
-              name='format'
-              options={[
-                { label: 'JSON', value: 'json' },
-                {
-                  label: 'CSV',
-                  value: 'csv'
-                }
-              ]}
-              inline
-            />
-          </ListItem>
-        </Section>
+          </div>
+        </HookedInputCheckbox>
       </Spacer>
 
       <Button variant='primary' type='submit' disabled={isLoading}>

--- a/apps/exports/src/components/Form/types.d.ts
+++ b/apps/exports/src/components/Form/types.d.ts
@@ -65,5 +65,6 @@ declare module 'AppForm' {
     includes: string[]
     format: ExportFormat
     filters?: AllFilters
+    useCustomFields?: boolean
   }
 }

--- a/apps/exports/src/data/fields.ts
+++ b/apps/exports/src/data/fields.ts
@@ -1,0 +1,29 @@
+import { type Market, type Order } from '@commercelayer/sdk'
+import { type AllowedResourceType } from 'App'
+
+type OrdersField = keyof Order | `market.${keyof Market}`
+const orders: OrdersField[] = [
+  'number',
+  'status',
+  'payment_status',
+  'fulfillment_status',
+  'customer_email',
+  'coupon_code',
+  'formatted_subtotal_amount',
+  'formatted_shipping_amount',
+  'formatted_payment_method_amount',
+  'formatted_discount_amount',
+  'formatted_total_tax_amount',
+  'formatted_total_amount_with_taxes',
+  'skus_count',
+  'payment_source_details',
+  'placed_at',
+  'metadata',
+  'market.id'
+]
+
+export const customFieldsSubset: Partial<
+  Record<AllowedResourceType, string[]>
+> = {
+  orders
+}

--- a/apps/exports/src/pages/NewExportPage.tsx
+++ b/apps/exports/src/pages/NewExportPage.tsx
@@ -1,6 +1,7 @@
 import { Form } from '#components/Form'
 import { adaptFormFiltersToSdk } from '#components/Form/Filters/utils'
 import { validateRecordsCount } from '#components/Form/validateRecordsCount'
+import { customFieldsSubset } from '#data/fields'
 import { isAvailableResource, showResourceNiceName } from '#data/resources'
 import { appRoutes } from '#data/routes'
 import { parseApiError } from '#utils/apiErrors'
@@ -81,6 +82,10 @@ const NewExportPage = (): React.JSX.Element | null => {
         dry_data: values.dryData,
         includes: values.includes,
         format: values.format,
+        fields:
+          values.useCustomFields === true
+            ? customFieldsSubset[resourceType]
+            : undefined,
         filters
       })
       setLocation(appRoutes.list.makePath())
@@ -112,6 +117,7 @@ const NewExportPage = (): React.JSX.Element | null => {
           defaultValues={{
             dryData: false,
             format: 'json',
+            useCustomFields: false,
             includes: []
           }}
           onSubmit={(values) => {

--- a/apps/exports/src/pages/NewExportPage.tsx
+++ b/apps/exports/src/pages/NewExportPage.tsx
@@ -77,6 +77,7 @@ const NewExportPage = (): React.JSX.Element | null => {
         resourceType,
         filters
       })
+
       await sdkClient.exports.create({
         resource_type: resourceType,
         dry_data: values.dryData,
@@ -84,7 +85,10 @@ const NewExportPage = (): React.JSX.Element | null => {
         format: values.format,
         fields:
           values.useCustomFields === true
-            ? customFieldsSubset[resourceType]
+            ? customFieldsSubset[resourceType]?.concat(
+                // we need to add all includes as fields or they will be ignored
+                (values.includes ?? []).map((res) => `${res}.*`)
+              )
             : undefined,
         filters
       })


### PR DESCRIPTION
Closes commercelayer/issues-app#48

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Update UI to have select and checkbox to control format (csv / json) and dry_data (importable)
- Add subset of fields to export orders with the "simple format" controlled checkbox

<img width="716" alt="image" src="https://github.com/user-attachments/assets/f756f0d2-be37-4d10-bae7-bd8014c08a56" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
