### PR TITLE
Update app-elements (including tailwindcss)

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/bundles/src/main.tsx
+++ b/apps/bundles/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/customers/src/main.tsx
+++ b/apps/customers/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.45.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/exports/src/main.tsx
+++ b/apps/exports/src/main.tsx
@@ -7,9 +7,12 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/gift_cards/src/main.tsx
+++ b/apps/gift_cards/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.45.0",
     "@vitejs/plugin-react": "^4.6.0",

--- a/apps/imports/src/main.tsx
+++ b/apps/imports/src/main.tsx
@@ -7,9 +7,12 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/inventory/src/main.tsx
+++ b/apps/inventory/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/my_sample_app/package.json
+++ b/apps/my_sample_app/package.json
@@ -25,7 +25,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "^6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/my_sample_app/src/main.tsx
+++ b/apps/my_sample_app/src/main.tsx
@@ -8,10 +8,13 @@ import {
   type ClAppProps,
   type TokenProviderAllowedAppSlug
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "^6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/orders/src/main.tsx
+++ b/apps/orders/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/price_lists/src/main.tsx
+++ b/apps/price_lists/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/promotions/src/main.tsx
+++ b/apps/promotions/src/main.tsx
@@ -8,10 +8,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/returns/src/main.tsx
+++ b/apps/returns/src/main.tsx
@@ -8,10 +8,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/shipments/src/main.tsx
+++ b/apps/shipments/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/sku_lists/src/main.tsx
+++ b/apps/sku_lists/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/src/main.tsx
+++ b/apps/skus/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/stock_transfers/src/main.tsx
+++ b/apps/stock_transfers/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "^6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/subscriptions/src/main.tsx
+++ b/apps/subscriptions/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/tags/src/main.tsx
+++ b/apps/tags/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/webhooks/src/main.tsx
+++ b/apps/webhooks/src/main.tsx
@@ -7,10 +7,13 @@ import {
   createApp,
   type ClAppProps
 } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { StrictMode } from 'react'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 const isDev = Boolean(import.meta.env.DEV)
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "@commercelayer/sdk": "^6.45.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "5.7.0",
+    "@commercelayer/app-elements": "6.0.0",
     "lodash-es": "^4.17.21",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/packages/index/src/main.tsx
+++ b/packages/index/src/main.tsx
@@ -1,5 +1,8 @@
 import { createApp } from '@commercelayer/app-elements'
-import '@commercelayer/app-elements/style.css'
 import { App } from './App'
+
+import '@commercelayer/app-elements/vendor.css'
+
+import '@commercelayer/app-elements/style.css'
 
 createApp((props) => <App {...props} />, 'index')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -115,8 +115,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -197,8 +197,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.1.0)(typescript@5.8.3)
@@ -288,8 +288,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -370,8 +370,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.1.0)(typescript@5.8.3)
@@ -464,8 +464,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -549,8 +549,8 @@ importers:
   apps/my_sample_app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -634,8 +634,8 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -722,8 +722,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -807,8 +807,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -895,8 +895,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -980,8 +980,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -1065,8 +1065,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -1153,8 +1153,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -1244,8 +1244,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -1326,8 +1326,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -1411,8 +1411,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -1493,8 +1493,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: 6.45.0
         version: 6.45.0
@@ -1599,8 +1599,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -1657,8 +1657,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 5.7.0
-        version: 5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
+        specifier: 6.0.0
+        version: 6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1850,8 +1850,8 @@ packages:
     resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
     engines: {node: '>=6.9.0'}
 
-  '@commercelayer/app-elements@5.7.0':
-    resolution: {integrity: sha512-Qp1o3t6RiLRYEq57wft4JsqADbta03tgBANpPaO/7jSTqZ37P1Albs8oXnbotibmXktjjj3xAZ9bCR/PHr5RoQ==}
+  '@commercelayer/app-elements@6.0.0':
+    resolution: {integrity: sha512-Asnt1uKmU51BTKaRZ8oBymMIAz+3eWGJck5K5MJ+SJbfFa++XMrRC78dQ/yVcyo8RpvzMWMrIDRiPQEHf8jTvQ==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -5170,8 +5170,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-i18next@15.6.0:
-    resolution: {integrity: sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==}
+  react-i18next@15.6.1:
+    resolution: {integrity: sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==}
     peerDependencies:
       i18next: '>= 23.2.3'
       react: '>= 16.8.0'
@@ -6327,7 +6327,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@commercelayer/app-elements@5.7.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))':
+  '@commercelayer/app-elements@6.0.0(@commercelayer/sdk@6.45.0)(query-string@8.2.0)(react-dom@19.1.0(react@19.1.0))(react-gtm-module@2.0.11)(react-hook-form@7.60.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(wouter@3.7.1(react@19.1.0))':
     dependencies:
       '@commercelayer/js-auth': 6.7.2
       '@commercelayer/sdk': 6.45.0
@@ -6352,7 +6352,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-gtm-module: 2.0.11
       react-hook-form: 7.60.0(react@19.1.0)
-      react-i18next: 15.6.0(i18next@25.3.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
+      react-i18next: 15.6.1(i18next@25.3.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       react-select: 5.10.2(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-toastify: 11.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-tooltip: 5.29.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -10129,7 +10129,7 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  react-i18next@15.6.0(i18next@25.3.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3):
+  react-i18next@15.6.1(i18next@25.3.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3):
     dependencies:
       '@babel/runtime': 7.27.6
       html-parse-stringify: 3.0.1


### PR DESCRIPTION
## What I did

I updated Tailwind CSS to the latest v4.x.

This contains a breaking change.

You'll need to update all the `main.tsx` file of each app prepending the `vendor.css` to the `style.css`

```diff
+ import '@commercelayer/app-elements/vendor.css'

import '@commercelayer/app-elements/style.css'
```