### PR TITLE
Add filters to all promotion statuses

### DIFF
--- a/apps/promotions/src/data/filters.ts
+++ b/apps/promotions/src/data/filters.ts
@@ -1,193 +1,164 @@
 import type { FiltersInstructions } from '@commercelayer/app-elements'
 import type { PromotionType } from './promotions/config'
 
-export const filtersInstructions: FiltersInstructions = [
-  // {
-  //   label: 'Status',
-  //   type: 'options',
-  //   sdk: [
-  //     {
-  //       predicate: 'starts_at_lteq',
-  //       parseFormValue: (value) => value === 'active' ? new Date().toJSON() : null
-  //     },
-  //     {
-  //       predicate: 'expires_at_gteq',
-  //       parseFormValue: (value) => value === 'active' ? new Date().toJSON() : null
-  //     },
-  //     {
-  //       predicate: 'starts_at_gteq',
-  //       parseFormValue: (value) => value === 'upcoming' ? new Date().toJSON() : null
-  //     },
-  //     {
-  //       predicate: 'expires_at_lteq',
-  //       parseFormValue: (value) => value === 'expired' ? new Date().toJSON() : null
-  //     },
-  //     {
-  //       predicate: 'disabled_at',
-  //       parseFormValue: (value) => value === 'disabled' ? 'true' : null
-  //     }
-  //   ],
-  //   render: {
-  //     component: 'inputToggleButton',
-  //     props: {
-  //       mode: 'multi',
-  //       options: [
-  //         { value: 'active', label: 'Active' },
-  //         { value: 'upcoming', label: 'Upcoming' },
-  //         { value: 'expired', label: 'Expired' },
-  //         { value: 'disabled', label: 'Disabled' }
-  //       ]
-  //     }
-  //   }
-  // },
-
-  {
-    label: 'Type',
-    type: 'options',
-    sdk: {
-      predicate: 'type_in',
-      defaultOptions: [
-        'buy_x_pay_y_promotions',
-        'fixed_amount_promotions',
-        'fixed_price_promotions',
-        'free_gift_promotions',
-        'free_shipping_promotions',
-        'percentage_discount_promotions',
-        'external_promotions',
-        'flex_promotions'
-      ]
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'multi',
-        options: [
-          { value: 'buy_x_pay_y_promotions', label: 'Buy X pay Y' },
-          { value: 'fixed_amount_promotions', label: 'Fixed amount' },
-          { value: 'fixed_price_promotions', label: 'Fixed price' },
-          { value: 'free_gift_promotions', label: 'Free gift' },
-          { value: 'free_shipping_promotions', label: 'Free shipping' },
-          { value: 'percentage_discount_promotions', label: 'Perc. discount' },
-          { value: 'external_promotions', label: 'External' },
-          { value: 'flex_promotions', label: 'Flex' }
-        ] as Array<{ value: PromotionType; label: string }>
-      }
-    }
-  },
-
-  {
-    label: 'Coupons',
-    type: 'options',
-    sdk: {
-      predicate: 'coupons_code_present'
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'single',
-        options: [
-          { value: 'true', label: 'With coupons' },
-          { value: 'false', label: 'Without coupons' }
-        ]
-      }
-    }
-  },
-
-  {
-    label: 'Priority',
-    type: 'options',
-    sdk: {
-      predicate: 'priority_null'
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'single',
-        options: [
-          { value: 'false', label: 'Has priority' },
-          { value: 'true', label: "Doesn't have priority" }
-        ]
-      }
-    }
-  },
-
-  {
-    label: 'Exclusive',
-    type: 'options',
-    sdk: {
-      predicate: 'exclusive_true'
-    },
-    render: {
-      component: 'inputToggleButton',
-      props: {
-        mode: 'single',
-        options: [
-          { value: 'true', label: 'Is exclusive' },
-          { value: 'false', label: "Isn't exclusive" }
-        ]
-      }
-    }
-  },
-
-  // {
-  //   hidden: true,
-  //   label: 'Starts at',
-  //   type: 'textSearch',
-  //   sdk: {
-  //     predicate: 'starts_at_lteq'
-  //   },
-  //   render: {
-  //     component: 'input'
-  //   }
-  // },
-  // {
-  //   hidden: true,
-  //   label: 'Starts at gt',
-  //   type: 'textSearch',
-  //   sdk: {
-  //     predicate: 'starts_at_gt'
-  //   },
-  //   render: {
-  //     component: 'input'
-  //   }
-  // },
-  // {
-  //   hidden: true,
-  //   label: 'Expires at',
-  //   type: 'textSearch',
-  //   sdk: {
-  //     predicate: 'expires_at_gteq'
-  //   },
-  //   render: {
-  //     component: 'input'
-  //   }
-  // },
-  // {
-  //   label: 'Disable',
-  //   type: 'textSearch',
-  //   sdk: {
-  //     predicate: 'disabled_at_null'
-  //   },
-  //   render: {
-  //     component: 'input'
-  //   }
-  // },
-
-  {
-    label: 'Search',
-    type: 'textSearch',
-    sdk: {
-      predicate: ['name', 'coupons_code'].join('_or_') + '_cont'
-    },
-    render: {
-      component: 'searchBar'
-    }
-  }
-]
-
-export const predicateWhitelist = [
+const filtersWhitelist: FiltersInstructions = [
   'starts_at_lteq',
   'expires_at_gteq',
   'disabled_at_null',
   'starts_at_gt'
-]
+].map((predicate) => ({
+  hidden: true,
+  label: predicate,
+  type: 'textSearch',
+  sdk: {
+    predicate
+  },
+  render: {
+    component: 'input'
+  }
+}))
+
+export const filtersInstructions: FiltersInstructions = filtersWhitelist.concat(
+  [
+    // {
+    //   label: 'Status',
+    //   type: 'options',
+    //   sdk: [
+    //     {
+    //       predicate: 'starts_at_lteq',
+    //       parseFormValue: (value) => value === 'active' ? new Date().toJSON() : null
+    //     },
+    //     {
+    //       predicate: 'expires_at_gteq',
+    //       parseFormValue: (value) => value === 'active' ? new Date().toJSON() : null
+    //     },
+    //     {
+    //       predicate: 'starts_at_gteq',
+    //       parseFormValue: (value) => value === 'upcoming' ? new Date().toJSON() : null
+    //     },
+    //     {
+    //       predicate: 'expires_at_lteq',
+    //       parseFormValue: (value) => value === 'expired' ? new Date().toJSON() : null
+    //     },
+    //     {
+    //       predicate: 'disabled_at',
+    //       parseFormValue: (value) => value === 'disabled' ? 'true' : null
+    //     }
+    //   ],
+    //   render: {
+    //     component: 'inputToggleButton',
+    //     props: {
+    //       mode: 'multi',
+    //       options: [
+    //         { value: 'active', label: 'Active' },
+    //         { value: 'upcoming', label: 'Upcoming' },
+    //         { value: 'expired', label: 'Expired' },
+    //         { value: 'disabled', label: 'Disabled' }
+    //       ]
+    //     }
+    //   }
+    // },
+
+    {
+      label: 'Type',
+      type: 'options',
+      sdk: {
+        predicate: 'type_in',
+        defaultOptions: [
+          'buy_x_pay_y_promotions',
+          'fixed_amount_promotions',
+          'fixed_price_promotions',
+          'free_gift_promotions',
+          'free_shipping_promotions',
+          'percentage_discount_promotions',
+          'external_promotions',
+          'flex_promotions'
+        ]
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'multi',
+          options: [
+            { value: 'buy_x_pay_y_promotions', label: 'Buy X pay Y' },
+            { value: 'fixed_amount_promotions', label: 'Fixed amount' },
+            { value: 'fixed_price_promotions', label: 'Fixed price' },
+            { value: 'free_gift_promotions', label: 'Free gift' },
+            { value: 'free_shipping_promotions', label: 'Free shipping' },
+            {
+              value: 'percentage_discount_promotions',
+              label: 'Perc. discount'
+            },
+            { value: 'external_promotions', label: 'External' },
+            { value: 'flex_promotions', label: 'Flex' }
+          ] as Array<{ value: PromotionType; label: string }>
+        }
+      }
+    },
+
+    {
+      label: 'Coupons',
+      type: 'options',
+      sdk: {
+        predicate: 'coupons_code_present'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'single',
+          options: [
+            { value: 'true', label: 'With coupons' },
+            { value: 'false', label: 'Without coupons' }
+          ]
+        }
+      }
+    },
+
+    {
+      label: 'Priority',
+      type: 'options',
+      sdk: {
+        predicate: 'priority_null'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'single',
+          options: [
+            { value: 'false', label: 'Has priority' },
+            { value: 'true', label: "Doesn't have priority" }
+          ]
+        }
+      }
+    },
+
+    {
+      label: 'Exclusive',
+      type: 'options',
+      sdk: {
+        predicate: 'exclusive_true'
+      },
+      render: {
+        component: 'inputToggleButton',
+        props: {
+          mode: 'single',
+          options: [
+            { value: 'true', label: 'Is exclusive' },
+            { value: 'false', label: "Isn't exclusive" }
+          ]
+        }
+      }
+    },
+
+    {
+      label: 'Search',
+      type: 'textSearch',
+      sdk: {
+        predicate: ['name', 'coupons_code'].join('_or_') + '_cont'
+      },
+      render: {
+        component: 'searchBar'
+      }
+    }
+  ]
+)

--- a/apps/promotions/src/pages/FiltersPage.tsx
+++ b/apps/promotions/src/pages/FiltersPage.tsx
@@ -1,5 +1,5 @@
 import type { PageProps } from '#components/Routes'
-import { filtersInstructions, predicateWhitelist } from '#data/filters'
+import { filtersInstructions } from '#data/filters'
 import { appRoutes } from '#data/routes'
 import { PageLayout, useResourceFilters } from '@commercelayer/app-elements'
 import { useLocation } from 'wouter'
@@ -7,8 +7,7 @@ import { useLocation } from 'wouter'
 function Page(props: PageProps<typeof appRoutes.filters>): React.JSX.Element {
   const [, setLocation] = useLocation()
   const { FiltersForm, adapters } = useResourceFilters({
-    instructions: filtersInstructions,
-    predicateWhitelist
+    instructions: filtersInstructions
   })
 
   return (
@@ -21,6 +20,7 @@ function Page(props: PageProps<typeof appRoutes.filters>): React.JSX.Element {
         onClick() {
           setLocation(
             appRoutes.promotionList.makePath(
+              {},
               adapters.adaptUrlQueryToUrlQuery({
                 queryString: location.search
               })

--- a/apps/promotions/src/pages/HomePage.tsx
+++ b/apps/promotions/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { filtersInstructions, predicateWhitelist } from '#data/filters'
+import { filtersInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import { usePromotionPermission } from '#hooks/usePromotionPermission'
@@ -23,8 +23,7 @@ function HomePage(): React.JSX.Element {
   const [, setLocation] = useLocation()
 
   const { SearchWithNav, adapters } = useResourceFilters({
-    instructions: filtersInstructions,
-    predicateWhitelist
+    instructions: filtersInstructions
   })
 
   return (

--- a/apps/promotions/src/pages/PromotionListPage.tsx
+++ b/apps/promotions/src/pages/PromotionListPage.tsx
@@ -1,7 +1,7 @@
 import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemPromotion } from '#components/ListItemPromotion'
 import type { PageProps } from '#components/Routes'
-import { filtersInstructions, predicateWhitelist } from '#data/filters'
+import { filtersInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import { appRoutes } from '#data/routes'
 import {
@@ -25,11 +25,8 @@ function Page(
 
   const { SearchWithNav, FilteredList, viewTitle, hasActiveFilter } =
     useResourceFilters({
-      instructions: filtersInstructions,
-      predicateWhitelist
+      instructions: filtersInstructions
     })
-
-  const hideFiltersNav = !(viewTitle == null)
 
   /** Whether the user is viewing only active promotions */
   const isActivePreset =
@@ -58,7 +55,6 @@ function Page(
         onFilterClick={(queryString) => {
           setLocation(appRoutes.filters.makePath({}, queryString))
         }}
-        hideFiltersNav={hideFiltersNav}
       />
 
       <Spacer bottom='14'>


### PR DESCRIPTION
Closes commercelayer/issues-app#427

## What I did

I added the possibility to apply filters to all promotion statuses in the list.

## How to test

<img width="712" height="363" alt="Screenshot 2025-08-05 alle 19 02 02" src="https://github.com/user-attachments/assets/9341f7af-020d-442d-a68b-2182b24acac3" />
