### PR TITLE
Allow to reset shipment status for upcoming and purchased shipments

### DIFF
--- a/apps/shipments/src/hooks/useViewStatus.tsx
+++ b/apps/shipments/src/hooks/useViewStatus.tsx
@@ -42,6 +42,17 @@ export function useViewStatus(shipment: Shipment): ViewStatus {
     }
 
     switch (shipment.status) {
+      case 'upcoming':
+        // edge case when shipment is stuck in upcoming status
+        // upcoming shipments are only accessible from the orders app.
+        result.footerActions = [
+          {
+            label: 'Start picking',
+            triggerAttribute: '_picking'
+          }
+        ]
+        break
+
       case 'picking':
         result.footerActions = [
           {
@@ -94,6 +105,12 @@ export function useViewStatus(shipment: Shipment): ViewStatus {
               ]
             }
           } else {
+            result.contextActions = [
+              {
+                label: t('apps.shipments.actions.set_back_to_picking'),
+                triggerAttribute: '_picking'
+              }
+            ]
             result.footerActions = [
               {
                 label: t('apps.shipments.actions.set_ready_to_ship'),
@@ -107,8 +124,8 @@ export function useViewStatus(shipment: Shipment): ViewStatus {
       case 'ready_to_ship':
         result.contextActions = [
           {
-            label: t('apps.shipments.actions.set_back_to_packing'),
-            triggerAttribute: '_packing'
+            label: t('apps.shipments.actions.set_back_to_picking'),
+            triggerAttribute: '_picking'
           }
         ]
         result.footerActions = [


### PR DESCRIPTION
Closes commercelayer/issues-app#342
Closes commercelayer/issues-app#363

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Shipment status can now be reset to picking, even after the shipping label has been purchased.
- Upcoming shipments can now be manually moved to picking status.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
