### PR TITLE
Update app-elements and tsconfig (moduleResolution)

### DIFF
--- a/apps/bundles/i18n.d.ts
+++ b/apps/bundles/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/bundles/tsconfig.json
+++ b/apps/bundles/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/bundles/tsconfig.node.json
+++ b/apps/bundles/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/customers/i18n.d.ts
+++ b/apps/customers/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from '@commercelayer/app-elements'
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/customers/src/data/lists.ts
+++ b/apps/customers/src/data/lists.ts
@@ -1,4 +1,4 @@
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FormFullValues } from '@commercelayer/app-elements'
 
 export type ListType = 'all'
 

--- a/apps/customers/tsconfig.json
+++ b/apps/customers/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/customers/tsconfig.node.json
+++ b/apps/customers/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/exports/i18n.d.ts
+++ b/apps/exports/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.46.0",
     "@testing-library/jest-dom": "^6.8.0",

--- a/apps/exports/src/components/Form/ResourceFinder/index.tsx
+++ b/apps/exports/src/components/Form/ResourceFinder/index.tsx
@@ -2,9 +2,12 @@ import {
   type SearchParams,
   type SearchableResource
 } from '#components/Form/ResourceFinder/utils'
-import { InputSelect, Label } from '@commercelayer/app-elements'
-import { type InputSelectValue } from '@commercelayer/app-elements/dist/ui/forms/InputSelect'
-import { type PossibleSelectValue } from '@commercelayer/app-elements/dist/ui/forms/InputSelect/InputSelect'
+import {
+  InputSelect,
+  Label,
+  type InputSelectValue,
+  type PossibleSelectValue
+} from '@commercelayer/app-elements'
 import { useEffect, useState } from 'react'
 import { fetchInitialResources, fetchResourcesByHint } from './utils'
 

--- a/apps/exports/src/components/Form/ResourceFinder/utils.ts
+++ b/apps/exports/src/components/Form/ResourceFinder/utils.ts
@@ -1,4 +1,4 @@
-import { type InputSelectValue } from '@commercelayer/app-elements/dist/ui/forms/InputSelect'
+import type { InputSelectValue } from '@commercelayer/app-elements'
 import type {
   CommerceLayerClient,
   ListResponse,

--- a/apps/exports/tsconfig.json
+++ b/apps/exports/tsconfig.json
@@ -19,7 +19,7 @@
     "noEmit": true,
     "esModuleInterop": false,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/apps/exports/tsconfig.node.json
+++ b/apps/exports/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/gift_cards/i18n.d.ts
+++ b/apps/gift_cards/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/gift_cards/tsconfig.json
+++ b/apps/gift_cards/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/gift_cards/tsconfig.node.json
+++ b/apps/gift_cards/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/imports/i18n.d.ts
+++ b/apps/imports/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/eslint-config-ts-react": "^2.2.0",
     "@commercelayer/sdk": "6.46.0",
     "@vitejs/plugin-react": "^5.0.3",

--- a/apps/imports/src/components/ResourceFinder/index.tsx
+++ b/apps/imports/src/components/ResourceFinder/index.tsx
@@ -1,12 +1,10 @@
 import {
   InputSelect,
   Label,
-  isSingleValueSelected
-} from '@commercelayer/app-elements'
-import {
+  isSingleValueSelected,
   type InputSelectProps,
   type InputSelectValue
-} from '@commercelayer/app-elements/dist/ui/forms/InputSelect'
+} from '@commercelayer/app-elements'
 import { type CommerceLayerClient } from '@commercelayer/sdk'
 import { type AllowedParentResource, type AllowedResourceType } from 'App'
 import { useEffect, useRef, useState } from 'react'

--- a/apps/imports/src/components/ResourceFinder/utils.ts
+++ b/apps/imports/src/components/ResourceFinder/utils.ts
@@ -1,4 +1,4 @@
-import { type InputSelectValue } from '@commercelayer/app-elements/dist/ui/forms/InputSelect'
+import { type InputSelectValue } from '@commercelayer/app-elements'
 import type {
   CommerceLayerClient,
   ListResponse,

--- a/apps/imports/tsconfig.json
+++ b/apps/imports/tsconfig.json
@@ -19,7 +19,7 @@
     "noEmit": true,
     "esModuleInterop": false,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/apps/imports/tsconfig.node.json
+++ b/apps/imports/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/inventory/i18n.d.ts
+++ b/apps/inventory/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/inventory/src/hooks/useAddItemOverlay.tsx
+++ b/apps/inventory/src/hooks/useAddItemOverlay.tsx
@@ -1,12 +1,12 @@
 import { ListEmptyStateSKUs } from '#components/ListEmptyStateSKUs'
 import { ListItemSku } from '#components/ListItemSku'
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 import {
   Card,
   PageLayout,
   useOverlay,
   useResourceFilters
 } from '@commercelayer/app-elements'
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 import type { Sku } from '@commercelayer/sdk'
 import { useState } from 'react'
 import { navigate, useSearch } from 'wouter/use-browser-location'

--- a/apps/inventory/tsconfig.json
+++ b/apps/inventory/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/inventory/tsconfig.node.json
+++ b/apps/inventory/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/my_sample_app/i18n.d.ts
+++ b/apps/my_sample_app/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/my_sample_app/package.json
+++ b/apps/my_sample_app/package.json
@@ -25,7 +25,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "^6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/my_sample_app/tsconfig.json
+++ b/apps/my_sample_app/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/my_sample_app/tsconfig.node.json
+++ b/apps/my_sample_app/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/orders/i18n.d.ts
+++ b/apps/orders/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "^6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/orders/src/components/NewOrder/languages.ts
+++ b/apps/orders/src/components/NewOrder/languages.ts
@@ -1,5 +1,7 @@
-import type { InputSelectValue } from '@commercelayer/app-elements'
-import type { GroupedSelectValues } from '@commercelayer/app-elements/dist/ui/forms/InputSelect/InputSelect'
+import type {
+  GroupedSelectValues,
+  InputSelectValue
+} from '@commercelayer/app-elements'
 
 const supportedLanguages = ['en', 'it', 'de', 'pl', 'es', 'fr', 'hu', 'pt']
 

--- a/apps/orders/src/components/OrderSummary/hooks/useAddItemOverlay.tsx
+++ b/apps/orders/src/components/OrderSummary/hooks/useAddItemOverlay.tsx
@@ -1,5 +1,6 @@
 import { ListEmptyState } from '#components/ListEmptyState'
 import { ListItemSkuBundle } from '#components/OrderSummary/ListItemSkuBundle'
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 import {
   PageHeading,
   Spacer,
@@ -7,7 +8,6 @@ import {
   useResourceFilters,
   useTranslation
 } from '@commercelayer/app-elements'
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 import type { Bundle, Order, Sku } from '@commercelayer/sdk'
 import { useRef } from 'react'
 import { navigate, useSearch } from 'wouter/use-browser-location'

--- a/apps/orders/src/data/lists.ts
+++ b/apps/orders/src/data/lists.ts
@@ -1,5 +1,5 @@
+import type { FormFullValues } from '@commercelayer/app-elements'
 import { t } from '@commercelayer/app-elements'
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 
 export type ListType =
   | 'awaitingApproval'

--- a/apps/orders/src/hooks/useOrderToolbar.tsx
+++ b/apps/orders/src/hooks/useOrderToolbar.tsx
@@ -9,9 +9,9 @@ import { useTriggerAttribute } from '#hooks/useTriggerAttribute'
 import {
   useTokenProvider,
   useTranslation,
-  type DropdownItemProps
+  type DropdownItemProps,
+  type PageHeadingToolbarProps
 } from '@commercelayer/app-elements'
-import type { PageHeadingToolbarProps } from '@commercelayer/app-elements/dist/ui/atoms/PageHeading/PageHeadingToolbar'
 import { type Order } from '@commercelayer/sdk'
 import { useMemo } from 'react'
 import { useLocation } from 'wouter'

--- a/apps/orders/src/metricsApi/useListCounters.ts
+++ b/apps/orders/src/metricsApi/useListCounters.ts
@@ -2,10 +2,10 @@ import { makeInstructions } from '#data/filters'
 import { presets } from '#data/lists'
 import {
   useResourceFilters,
-  useTokenProvider
+  useTokenProvider,
+  type MetricsFilters,
+  type UiFilterValue
 } from '@commercelayer/app-elements'
-import type { MetricsFilters } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/adaptSdkToMetrics'
-import type { UiFilterValue } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 import type { QueryFilter } from '@commercelayer/sdk'
 import useSWR, { type SWRResponse } from 'swr'
 import { metricsApiFetcher } from './fetcher'

--- a/apps/orders/src/pages/OrderDetails.tsx
+++ b/apps/orders/src/pages/OrderDetails.tsx
@@ -27,9 +27,9 @@ import {
   isMockedId,
   useAppLinking,
   useTokenProvider,
-  useTranslation
+  useTranslation,
+  type ToolbarItem
 } from '@commercelayer/app-elements'
-import type { ToolbarItem } from '@commercelayer/app-elements/dist/ui/composite/Toolbar'
 import { useLocation, useRoute } from 'wouter'
 
 function OrderDetails(): React.JSX.Element {

--- a/apps/orders/tsconfig.json
+++ b/apps/orders/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/orders/tsconfig.node.json
+++ b/apps/orders/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/price_lists/i18n.d.ts
+++ b/apps/price_lists/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/price_lists/src/hooks/useAddItemOverlay.tsx
+++ b/apps/price_lists/src/hooks/useAddItemOverlay.tsx
@@ -1,12 +1,12 @@
 import { ListEmptyStateSku } from '#components/ListEmptyStateSku'
 import { ListItemSku } from '#components/ListItemSku'
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 import {
   Card,
   PageLayout,
   useOverlay,
   useResourceFilters
 } from '@commercelayer/app-elements'
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 import type { Sku } from '@commercelayer/sdk'
 import { useState } from 'react'
 import { navigate, useSearch } from 'wouter/use-browser-location'

--- a/apps/price_lists/tsconfig.json
+++ b/apps/price_lists/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/price_lists/tsconfig.node.json
+++ b/apps/price_lists/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/promotions/i18n.d.ts
+++ b/apps/promotions/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/promotions/src/data/lists.ts
+++ b/apps/promotions/src/data/lists.ts
@@ -1,4 +1,4 @@
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FormFullValues } from '@commercelayer/app-elements'
 
 export type ListType = 'active' | 'upcoming' | 'disabled'
 

--- a/apps/promotions/src/data/ruleBuilder/form/RuleBuilderForm.tsx
+++ b/apps/promotions/src/data/ruleBuilder/form/RuleBuilderForm.tsx
@@ -13,9 +13,9 @@ import {
   HookedInputSelect,
   Spacer,
   useCoreSdkProvider,
+  type GroupedSelectValues,
   type InputSelectValue
 } from '@commercelayer/app-elements'
-import type { GroupedSelectValues } from '@commercelayer/app-elements/dist/ui/forms/InputSelect/InputSelect'
 import type {
   CustomPromotionRule,
   FlexPromotion,

--- a/apps/promotions/tsconfig.json
+++ b/apps/promotions/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/promotions/tsconfig.node.json
+++ b/apps/promotions/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/returns/i18n.d.ts
+++ b/apps/returns/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/returns/src/data/filters.ts
+++ b/apps/returns/src/data/filters.ts
@@ -1,5 +1,5 @@
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 import { t } from '@commercelayer/app-elements'
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 
 export const instructions: FiltersInstructions = [
   {

--- a/apps/returns/src/data/lists.ts
+++ b/apps/returns/src/data/lists.ts
@@ -1,5 +1,5 @@
 import { t } from '@commercelayer/app-elements'
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FormFullValues } from '@commercelayer/app-elements'
 
 export type ListType =
   | 'requested'

--- a/apps/returns/src/metricsApi/useListCounters.ts
+++ b/apps/returns/src/metricsApi/useListCounters.ts
@@ -1,11 +1,10 @@
 import { presets, type ListType } from '#data/lists'
 import {
   makeDateYearsRange,
-  useTokenProvider
+  useTokenProvider,
+  type FormFullValues,
+  type ParsedScopes
 } from '@commercelayer/app-elements'
-
-import type { ParsedScopes } from '@commercelayer/app-elements/dist/providers/TokenProvider/getInfoFromJwt'
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 import castArray from 'lodash-es/castArray'
 import useSWR, { type SWRResponse } from 'swr'
 import { metricsApiFetcher } from './fetcher'

--- a/apps/returns/tsconfig.json
+++ b/apps/returns/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/returns/tsconfig.node.json
+++ b/apps/returns/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/shipments/i18n.d.ts
+++ b/apps/shipments/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/shipments/src/components/FormPackingFieldItems.tsx
+++ b/apps/shipments/src/components/FormPackingFieldItems.tsx
@@ -4,9 +4,9 @@ import {
   InputCheckboxGroup,
   ListItem,
   Text,
-  useTranslation
+  useTranslation,
+  type InputCheckboxGroupProps
 } from '@commercelayer/app-elements'
-import type { InputCheckboxGroupProps } from '@commercelayer/app-elements/dist/ui/forms/InputCheckboxGroup'
 import type { StockLineItem } from '@commercelayer/sdk'
 import { useMemo } from 'react'
 import { Controller } from 'react-hook-form'

--- a/apps/shipments/src/data/filters.ts
+++ b/apps/shipments/src/data/filters.ts
@@ -1,6 +1,6 @@
 import { getShipmentStatusName } from '#data/dictionaries'
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 import { t } from '@commercelayer/app-elements'
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
 import type { Shipment } from '@commercelayer/sdk'
 
 const allowedStatuses: Array<Shipment['status']> = [

--- a/apps/shipments/src/data/lists.ts
+++ b/apps/shipments/src/data/lists.ts
@@ -1,5 +1,5 @@
 import { t } from '@commercelayer/app-elements'
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FormFullValues } from '@commercelayer/app-elements'
 
 export type ListType =
   | 'picking'

--- a/apps/shipments/src/hooks/useShipmentToolbar.tsx
+++ b/apps/shipments/src/hooks/useShipmentToolbar.tsx
@@ -1,6 +1,6 @@
 import { useTriggerAttribute } from '#hooks/useTriggerAttribute'
 import { useViewStatus } from '#hooks/useViewStatus'
-import type { PageHeadingToolbarProps } from '@commercelayer/app-elements/dist/ui/atoms/PageHeading/PageHeadingToolbar'
+import type { PageHeadingToolbarProps } from '@commercelayer/app-elements'
 import type { Shipment } from '@commercelayer/sdk'
 import type { FC } from 'react'
 

--- a/apps/shipments/src/hooks/useViewStatus.tsx
+++ b/apps/shipments/src/hooks/useViewStatus.tsx
@@ -1,5 +1,8 @@
-import { hasBeenPurchased, useTranslation } from '@commercelayer/app-elements'
-import type { ActionButtonsProps } from '@commercelayer/app-elements/dist/ui/composite/ActionButtons'
+import {
+  hasBeenPurchased,
+  useTranslation,
+  type ActionButtonsProps
+} from '@commercelayer/app-elements'
 import type { Shipment, ShipmentUpdate } from '@commercelayer/sdk'
 import { useMemo } from 'react'
 import { useActiveStockTransfers } from './useActiveStockTransfers'

--- a/apps/shipments/src/metricsApi/useListCounters.ts
+++ b/apps/shipments/src/metricsApi/useListCounters.ts
@@ -1,9 +1,9 @@
 import { presets, type ListType } from '#data/lists'
 import {
   makeDateYearsRange,
-  useTokenProvider
+  useTokenProvider,
+  type ParsedScopes
 } from '@commercelayer/app-elements'
-import type { ParsedScopes } from '@commercelayer/app-elements/dist/providers/TokenProvider/getInfoFromJwt'
 import useSWR, { type SWRResponse } from 'swr'
 import { metricsApiFetcher } from './fetcher'
 

--- a/apps/shipments/tsconfig.json
+++ b/apps/shipments/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/shipments/tsconfig.node.json
+++ b/apps/shipments/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/sku_lists/i18n.d.ts
+++ b/apps/sku_lists/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/sku_lists/tsconfig.json
+++ b/apps/sku_lists/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/sku_lists/tsconfig.node.json
+++ b/apps/sku_lists/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/skus/i18n.d.ts
+++ b/apps/skus/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/tsconfig.json
+++ b/apps/skus/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/skus/tsconfig.node.json
+++ b/apps/skus/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/stock_transfers/i18n.d.ts
+++ b/apps/stock_transfers/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/stock_transfers/src/data/filters.ts
+++ b/apps/stock_transfers/src/data/filters.ts
@@ -1,4 +1,4 @@
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 
 export const instructions: FiltersInstructions = [
   {

--- a/apps/stock_transfers/src/data/lists.ts
+++ b/apps/stock_transfers/src/data/lists.ts
@@ -1,4 +1,4 @@
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FormFullValues } from '@commercelayer/app-elements'
 
 export type ListType =
   | 'upcoming'

--- a/apps/stock_transfers/tsconfig.json
+++ b/apps/stock_transfers/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/stock_transfers/tsconfig.node.json
+++ b/apps/stock_transfers/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/subscriptions/i18n.d.ts
+++ b/apps/subscriptions/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "^6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/subscriptions/tsconfig.json
+++ b/apps/subscriptions/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/subscriptions/tsconfig.node.json
+++ b/apps/subscriptions/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/tags/i18n.d.ts
+++ b/apps/tags/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/tags/src/data/filters.ts
+++ b/apps/tags/src/data/filters.ts
@@ -1,4 +1,4 @@
-import type { FiltersInstructions } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FiltersInstructions } from '@commercelayer/app-elements'
 
 export const instructions: FiltersInstructions = [
   {

--- a/apps/tags/src/data/lists.ts
+++ b/apps/tags/src/data/lists.ts
@@ -1,4 +1,4 @@
-import type { FormFullValues } from '@commercelayer/app-elements/dist/ui/resources/useResourceFilters/types'
+import type { FormFullValues } from '@commercelayer/app-elements'
 
 export type ListType = 'all'
 

--- a/apps/tags/tsconfig.json
+++ b/apps/tags/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/tags/tsconfig.node.json
+++ b/apps/tags/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/apps/webhooks/i18n.d.ts
+++ b/apps/webhooks/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/apps/webhooks/src/components/Form/EventSelector.tsx
+++ b/apps/webhooks/src/components/Form/EventSelector.tsx
@@ -1,6 +1,5 @@
 import { getAllEventsForSelect } from '#data/events'
-import { HookedInputSelect } from '@commercelayer/app-elements'
-import type { HintProps } from '@commercelayer/app-elements/dist/ui/atoms/Hint'
+import { HookedInputSelect, type HintProps } from '@commercelayer/app-elements'
 
 interface Props {
   name: string

--- a/apps/webhooks/src/data/dictionaries.ts
+++ b/apps/webhooks/src/data/dictionaries.ts
@@ -3,7 +3,6 @@ import type {
   IconProps,
   TriggerAttribute
 } from '@commercelayer/app-elements'
-import type { DisplayStatus } from '@commercelayer/app-elements/dist/dictionaries/types'
 import type { Webhook, WebhookUpdate } from '@commercelayer/sdk'
 
 type ActionVariant = 'primary' | 'secondary'
@@ -42,7 +41,8 @@ export function getWebhookStatus(webhook: Webhook): WebhookAppStatus {
   return 'active'
 }
 
-type WebhookDisplayStatus = Pick<DisplayStatus, 'label'> & {
+interface WebhookDisplayStatus {
+  label: string
   variant: BadgeProps['variant']
 }
 

--- a/apps/webhooks/tsconfig.json
+++ b/apps/webhooks/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/apps/webhooks/tsconfig.node.json
+++ b/apps/webhooks/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/packages/common/i18n.d.ts
+++ b/packages/common/i18n.d.ts
@@ -1,10 +1,10 @@
-import type en from '@commercelayer/app-elements/dist/locales/en'
+import type { Translation } from "@commercelayer/app-elements"
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'translation'
     resources: {
-      translation: typeof en
+      translation: Translation
     }
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "@commercelayer/sdk": "^6.46.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -14,7 +14,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "6.2.0",
+    "@commercelayer/app-elements": "6.2.2",
     "lodash-es": "^4.17.21",
     "react": "19.1.1",
     "react-dom": "19.1.1",

--- a/packages/index/tsconfig.json
+++ b/packages/index/tsconfig.json
@@ -2,8 +2,15 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["vitest/globals", "vite/client"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "types": [
+      "vitest/globals",
+      "vite/client"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": false,
@@ -11,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": true,
@@ -21,13 +28,27 @@
     "jsx": "react-jsx",
     "baseUrl": "./",
     "paths": {
-      "#components/*": ["src/components/*"],
-      "#contexts/*": ["src/contexts/*"],
-      "#data/*": ["src/data/*"],
-      "#hooks/*": ["src/hooks/*"],
-      "#mocks": ["src/mocks/index"],
-      "#pages/*": ["src/pages/*"],
-      "#utils/*": ["src/utils/*"]
+      "#components/*": [
+        "src/components/*"
+      ],
+      "#contexts/*": [
+        "src/contexts/*"
+      ],
+      "#data/*": [
+        "src/data/*"
+      ],
+      "#hooks/*": [
+        "src/hooks/*"
+      ],
+      "#mocks": [
+        "src/mocks/index"
+      ],
+      "#pages/*": [
+        "src/pages/*"
+      ],
+      "#utils/*": [
+        "src/utils/*"
+      ]
     }
   },
   "include": [

--- a/packages/index/tsconfig.node.json
+++ b/packages/index/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -118,8 +118,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -200,8 +200,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.1.1)(typescript@5.9.2)
@@ -291,8 +291,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -373,8 +373,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/eslint-config-ts-react':
         specifier: ^2.2.0
         version: 2.2.0(eslint@8.57.1)(react@19.1.1)(typescript@5.9.2)
@@ -467,8 +467,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -552,8 +552,8 @@ importers:
   apps/my_sample_app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: ^6.46.0
         version: 6.46.0
@@ -637,8 +637,8 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: ^6.46.0
         version: 6.46.0
@@ -725,8 +725,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -810,8 +810,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -898,8 +898,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -983,8 +983,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -1068,8 +1068,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -1156,8 +1156,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -1247,8 +1247,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -1329,8 +1329,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: ^6.46.0
         version: 6.46.0
@@ -1414,8 +1414,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -1496,8 +1496,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: 6.46.0
         version: 6.46.0
@@ -1602,8 +1602,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       '@commercelayer/sdk':
         specifier: ^6.46.0
         version: 6.46.0
@@ -1660,8 +1660,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 6.2.0
-        version: 6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
+        specifier: 6.2.2
+        version: 6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1834,8 +1834,8 @@ packages:
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
-  '@commercelayer/app-elements@6.2.0':
-    resolution: {integrity: sha512-p8DmVn0FLdWr+H9oqUOrbT8wDk+agaj/pr4eLq8TfzUQm28yDIQ383/KEA6RqCPlzfmhjwRA3rW5aUr3OWtVQQ==}
+  '@commercelayer/app-elements@6.2.2':
+    resolution: {integrity: sha512-cFsBcMSkqaXkObNILBxgGWZQ1PqEQ7fyR1xJu43DV+LlYCRcUcsciklYAgBTBvM6S1dQvo4VxpHfqA+ror/WEg==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -6284,7 +6284,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@commercelayer/app-elements@6.2.0(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))':
+  '@commercelayer/app-elements@6.2.2(@commercelayer/sdk@6.46.0)(query-string@9.3.0)(react-dom@19.1.1(react@19.1.1))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(wouter@3.7.1(react@19.1.1))':
     dependencies:
       '@commercelayer/js-auth': 6.7.2
       '@commercelayer/sdk': 6.46.0


### PR DESCRIPTION
Closes commercelayer/issues-app#437

## What I did

I updated app-elements to the latest. It includes:

- Implementation of the resource selector in the RuleEngine. It will be used when the user selects `market`, `sku`, `sku_lists`, or `tag` in the condition field.
- Remove all not supported import paths (see https://github.com/commercelayer/app-elements/pull/997). This allow to use `modeResolution: "bundler"` in `tsconfig`, since `Node` is deprecated