### PR TITLE
Exports: prevent custom rules to be transformed

### DIFF
--- a/apps/exports/src/components/Form/index.tsx
+++ b/apps/exports/src/components/Form/index.tsx
@@ -46,7 +46,13 @@ export function Form({
                 name='filters'
                 control={methods.control}
                 render={({ field: { onChange } }) => (
-                  <Filters resourceType={resourceType} onChange={onChange} />
+                  <Filters
+                    resourceType={resourceType}
+                    onChange={(value) => {
+                      methods.setValue('filtersSource', 'ui')
+                      onChange(value)
+                    }}
+                  />
                 )}
               />
             </Tab>
@@ -57,8 +63,12 @@ export function Form({
               control={methods.control}
               render={({ field: { onChange } }) => (
                 <InputCode
-                  onDataReady={onChange}
+                  onDataReady={(value) => {
+                    methods.setValue('filtersSource', 'custom')
+                    onChange(value)
+                  }}
                   onDataResetRequest={() => {
+                    methods.setValue('filtersSource', 'custom')
                     onChange(undefined)
                   }}
                 />

--- a/apps/exports/src/components/Form/types.ts
+++ b/apps/exports/src/components/Form/types.ts
@@ -74,5 +74,6 @@ export interface ExportFormValues {
   includes: string[]
   format: ExportFormat
   filters?: AllFilters
+  filtersSource?: 'ui' | 'custom'
   useCustomFields?: boolean
 }

--- a/apps/exports/src/pages/NewExportPage.tsx
+++ b/apps/exports/src/pages/NewExportPage.tsx
@@ -70,7 +70,10 @@ const NewExportPage = (): React.JSX.Element | null => {
     setIsLoading(true)
 
     try {
-      const filters = adaptFormFiltersToSdk(values.filters, user?.timezone)
+      const filters =
+        values.filtersSource === 'custom'
+          ? values.filters
+          : adaptFormFiltersToSdk(values.filters, user?.timezone)
 
       await sdkClient.exports.create({
         resource_type: resourceType,


### PR DESCRIPTION
Closes commercelayer/issues-app#530

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

When user insert custom rules for a new export, they will not get transformed anymore by `adaptFormFiltersToSdk` helper, but used as they are.
To do this we use a flag `filtersSource` that is set as `custom` when user interacts with the custom rules input and it's set as `ui` when user interacts with the UI form inputs.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
