### PR TITLE
Exports: Add pause and resume buttons

### DIFF
--- a/apps/exports/src/components/Details/StatusBadge.tsx
+++ b/apps/exports/src/components/Details/StatusBadge.tsx
@@ -28,8 +28,8 @@ function getUiStatusVariant(apiStatus?: string): {
 
   if (apiStatus === 'interrupted') {
     return {
-      variant: 'danger',
-      label: 'interrupted'
+      variant: 'warning',
+      label: 'paused'
     }
   }
 

--- a/apps/exports/src/components/List/Item.tsx
+++ b/apps/exports/src/components/List/Item.tsx
@@ -22,12 +22,26 @@ interface Props {
 
 export function Item({ job }: Props): React.JSX.Element {
   const { canUser } = useTokenProvider()
-  const { deleteExport } = useListContext()
-  const [isDeleting, setIsDeleting] = useState(false)
+  const { deleteExport, interruptExport, resumeExport } = useListContext()
+  const [isActing, setIsActing] = useState(false)
+
+  const handleAction =
+    (action: () => Promise<void>) => (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsActing(true)
+      void action().finally(() => {
+        setIsActing(false)
+      })
+    }
 
   const canDelete =
-    (job.status === 'pending' || job.status === 'in_progress') &&
+    ['interrupted', 'pending', 'in_progress'].includes(job.status) &&
     canUser('destroy', 'exports')
+  const canPause =
+    ['pending', 'in_progress'].includes(job.status) &&
+    canUser('update', 'exports')
+  const canResume = job.status === 'interrupted' && canUser('update', 'exports')
 
   return (
     <Link href={appRoutes.details.makePath(job.id)} asChild>
@@ -40,25 +54,47 @@ export function Item({ job }: Props): React.JSX.Element {
             <DescriptionLine job={job} />
           </Text>
         </div>
-        {canDelete ? (
-          <Button
-            type='button'
-            variant='secondary'
-            disabled={isDeleting}
-            onClick={(e) => {
-              e.preventDefault()
-              e.stopPropagation()
-              setIsDeleting(true)
-              void deleteExport(job.id).finally(() => {
-                setIsDeleting(false)
-              })
-            }}
-          >
-            Cancel
-          </Button>
-        ) : (
-          <Icon name='caretRight' />
-        )}
+        <div className='flex items-center gap-2'>
+          {canPause && (
+            <Button
+              type='button'
+              variant='secondary'
+              disabled={isActing}
+              onClick={handleAction(async () => {
+                await interruptExport(job.id)
+              })}
+              size='small'
+            >
+              <Icon name='pause' />
+            </Button>
+          )}
+          {canResume && (
+            <Button
+              type='button'
+              variant='secondary'
+              disabled={isActing}
+              onClick={handleAction(async () => {
+                await resumeExport(job.id)
+              })}
+              size='small'
+            >
+              <Icon name='play' />
+            </Button>
+          )}
+          {canDelete && (
+            <Button
+              type='button'
+              variant='secondary'
+              disabled={isActing}
+              onClick={handleAction(async () => {
+                await deleteExport(job.id)
+              })}
+              size='small'
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
       </ListItem>
     </Link>
   )
@@ -71,7 +107,7 @@ function TaskIcon({ job }: { job: Export }): React.JSX.Element {
     return <RadialProgress percentage={job.progress ?? undefined} />
   }
 
-  if (status === 'pending') {
+  if (status === 'pending' || status === 'paused') {
     return <RadialProgress />
   }
 

--- a/apps/exports/src/components/List/Item.tsx
+++ b/apps/exports/src/components/List/Item.tsx
@@ -116,11 +116,11 @@ export function Item({ job }: Props): React.JSX.Element {
 function TaskIcon({ job }: { job: Export }): React.JSX.Element {
   const status = getUiStatus(job.status)
 
-  if (status === 'progress') {
+  if (status === 'progress' || status === 'paused') {
     return <RadialProgress percentage={job.progress ?? undefined} />
   }
 
-  if (status === 'pending' || status === 'paused') {
+  if (status === 'pending') {
     return <RadialProgress />
   }
 

--- a/apps/exports/src/components/List/Item.tsx
+++ b/apps/exports/src/components/List/Item.tsx
@@ -7,6 +7,7 @@ import {
   RadialProgress,
   StatusIcon,
   Text,
+  Tooltip,
   useTokenProvider
 } from '@commercelayer/app-elements'
 import { type Export } from '@commercelayer/sdk'
@@ -56,30 +57,40 @@ export function Item({ job }: Props): React.JSX.Element {
         </div>
         <div className='flex items-center gap-2'>
           {canPause && (
-            <Button
-              type='button'
-              variant='secondary'
-              disabled={isActing}
-              onClick={handleAction(async () => {
-                await interruptExport(job.id)
-              })}
-              size='small'
-            >
-              <Icon name='pause' />
-            </Button>
+            <Tooltip
+              label={
+                <Button
+                  type='button'
+                  variant='secondary'
+                  disabled={isActing}
+                  onClick={handleAction(async () => {
+                    await interruptExport(job.id)
+                  })}
+                  size='small'
+                >
+                  <Icon name='pause' />
+                </Button>
+              }
+              content='Pause export'
+            />
           )}
           {canResume && (
-            <Button
-              type='button'
-              variant='secondary'
-              disabled={isActing}
-              onClick={handleAction(async () => {
-                await resumeExport(job.id)
-              })}
-              size='small'
-            >
-              <Icon name='play' />
-            </Button>
+            <Tooltip
+              label={
+                <Button
+                  type='button'
+                  variant='secondary'
+                  disabled={isActing}
+                  onClick={handleAction(async () => {
+                    await resumeExport(job.id)
+                  })}
+                  size='small'
+                >
+                  <Icon name='play' />
+                </Button>
+              }
+              content='Resume export'
+            />
           )}
           {canDelete && (
             <Button

--- a/apps/exports/src/components/List/Item.tsx
+++ b/apps/exports/src/components/List/Item.tsx
@@ -67,6 +67,7 @@ export function Item({ job }: Props): React.JSX.Element {
                     await interruptExport(job.id)
                   })}
                   size='small'
+                  aria-label='Pause export'
                 >
                   <Icon name='pause' />
                 </Button>
@@ -85,6 +86,7 @@ export function Item({ job }: Props): React.JSX.Element {
                     await resumeExport(job.id)
                   })}
                   size='small'
+                  aria-label='Resume export'
                 >
                   <Icon name='play' />
                 </Button>

--- a/apps/exports/src/components/List/ItemDescriptionLine.tsx
+++ b/apps/exports/src/components/List/ItemDescriptionLine.tsx
@@ -20,26 +20,20 @@ export function DescriptionLine({ job }: Props): React.JSX.Element {
     <>
       {job.status === 'pending' ? (
         <div>Pending</div>
-      ) : job.status === 'in_progress' ? (
+      ) : job.status === 'in_progress' || job.status === 'interrupted' ? (
         <div>
           {(job.records_count ?? 0).toLocaleString()} records
           {job.progress != null
             ? ` · ${job.progress}% complete`
             : ' · in progress'}
-          {isEtaPending ? (
+          {job.status === 'in_progress' && isEtaPending ? (
             <>
               {' · '}
               <RemainingTime job={job} />
             </>
+          ) : job.status === 'interrupted' ? (
+            ' · Paused'
           ) : null}
-        </div>
-      ) : job.interrupted_at != null ? (
-        <div>
-          {formatDateWithPredicate({
-            predicate: 'Export interrupted',
-            isoDate: job.interrupted_at,
-            timezone: user?.timezone
-          })}
         </div>
       ) : job.status === 'completed' ? (
         <div>

--- a/apps/exports/src/components/List/Provider.tsx
+++ b/apps/exports/src/components/List/Provider.tsx
@@ -19,7 +19,7 @@ import {
   type ListExportContextValue
 } from './types'
 
-import { useIsChanged } from '@commercelayer/app-elements'
+import { toast, useIsChanged } from '@commercelayer/app-elements'
 import { initialState, initialValues } from './data'
 import { reducer } from './reducer'
 
@@ -96,6 +96,7 @@ export function ListExportProvider({
 
       await fetchList()
     } catch (error) {
+      toast('Could not delete export', { type: 'error' })
       console.error('Error interrupting export:', error)
     }
   }
@@ -105,6 +106,7 @@ export function ListExportProvider({
       await sdkClient.exports.update({ id: exportId, _interrupt: true })
       await fetchList()
     } catch (error) {
+      toast('Could not interrupt export', { type: 'error' })
       console.error('Error interrupting export:', error)
     }
   }
@@ -114,6 +116,7 @@ export function ListExportProvider({
       await sdkClient.exports.update({ id: exportId, _start: true })
       await fetchList()
     } catch (error) {
+      toast('Could not resume export', { type: 'error' })
       console.error('Error resuming export:', error)
     }
   }

--- a/apps/exports/src/components/List/Provider.tsx
+++ b/apps/exports/src/components/List/Provider.tsx
@@ -100,6 +100,24 @@ export function ListExportProvider({
     }
   }
 
+  const interruptExport = async (exportId: string): Promise<void> => {
+    try {
+      await sdkClient.exports.update({ id: exportId, _interrupt: true })
+      await fetchList()
+    } catch (error) {
+      console.error('Error interrupting export:', error)
+    }
+  }
+
+  const resumeExport = async (exportId: string): Promise<void> => {
+    try {
+      await sdkClient.exports.update({ id: exportId, _start: true })
+      await fetchList()
+    } catch (error) {
+      console.error('Error resuming export:', error)
+    }
+  }
+
   useEffect(
     function handleChangePageIgnoringFirstRender() {
       if (state.list?.meta.currentPage != null) {
@@ -132,7 +150,9 @@ export function ListExportProvider({
   const value: ListExportContextValue = {
     state,
     changePage,
-    deleteExport
+    deleteExport,
+    interruptExport,
+    resumeExport
   }
 
   return (

--- a/apps/exports/src/components/List/data.ts
+++ b/apps/exports/src/components/List/data.ts
@@ -12,5 +12,7 @@ export const initialState: ListExportContextState = {
 export const initialValues: ListExportContextValue = {
   state: initialState,
   changePage: () => undefined,
-  deleteExport: async () => undefined
+  deleteExport: async () => undefined,
+  interruptExport: async () => undefined,
+  resumeExport: async () => undefined
 }

--- a/apps/exports/src/components/List/types.ts
+++ b/apps/exports/src/components/List/types.ts
@@ -4,6 +4,8 @@ export interface ListExportContextValue {
   state: ListExportContextState
   changePage: (page: number) => void
   deleteExport: (id: string) => Promise<void>
+  interruptExport: (id: string) => Promise<void>
+  resumeExport: (id: string) => Promise<void>
 }
 
 export interface ListExportContextState {

--- a/apps/exports/src/components/List/utils.test.ts
+++ b/apps/exports/src/components/List/utils.test.ts
@@ -1,5 +1,5 @@
-import { getUiStatus, listHasProgressingItems } from './utils'
 import type { Export, ListResponse } from '@commercelayer/sdk'
+import { getUiStatus, listHasProgressingItems } from './utils'
 
 // getUiStatus
 describe('getUiStatus', () => {
@@ -7,8 +7,12 @@ describe('getUiStatus', () => {
     expect(getUiStatus('in_progress')).toBe('progress')
   })
 
-  test('should return `danger` status for the `<StatusIcon>` component when job is `interrupted`', () => {
-    expect(getUiStatus('interrupted')).toBe('danger')
+  test('should return `danger` status for the `<StatusIcon>` component when job is `failed`', () => {
+    expect(getUiStatus('failed')).toBe('danger')
+  })
+
+  test('should return `paused` status for the `<StatusIcon>` component when job is `interrupted`', () => {
+    expect(getUiStatus('interrupted')).toBe('paused')
   })
 
   test('should return `success` status for the `<StatusIcon>` component when job is `completed`', () => {

--- a/apps/exports/src/components/List/utils.ts
+++ b/apps/exports/src/components/List/utils.ts
@@ -1,6 +1,6 @@
 import type { Export, ListResponse } from '@commercelayer/sdk'
 
-type StatusUI = 'progress' | 'success' | 'danger' | 'pending'
+type StatusUI = 'progress' | 'success' | 'danger' | 'pending' | 'paused'
 
 /**
  * Get the relative status Union Type from the api status {@link https://docs.commercelayer.io/core/v/api-reference/imports/object}
@@ -12,7 +12,11 @@ export function getUiStatus(apiStatus?: string): StatusUI {
     return 'progress'
   }
 
-  if (apiStatus === 'interrupted' || apiStatus === 'failed') {
+  if (apiStatus === 'interrupted') {
+    return 'paused'
+  }
+
+  if (apiStatus === 'failed') {
     return 'danger'
   }
 

--- a/apps/exports/src/main.tsx
+++ b/apps/exports/src/main.tsx
@@ -1,11 +1,12 @@
 import {
+  type ClAppProps,
   CoreSdkProvider,
   ErrorBoundary,
   I18NProvider,
   MetaTags,
+  ToastContainer,
   TokenProvider,
-  createApp,
-  type ClAppProps
+  createApp
 } from '@commercelayer/app-elements'
 import { StrictMode } from 'react'
 import { App } from './App'
@@ -29,6 +30,7 @@ const Main = (props: ClAppProps): React.JSX.Element => (
         <I18NProvider>
           <CoreSdkProvider>
             <MetaTags />
+            <ToastContainer />
             <App routerBase={props?.routerBase} />
           </CoreSdkProvider>
         </I18NProvider>


### PR DESCRIPTION
Closes commercelayer/issues-app#578

## What I did

I've added pause (trigger attribute `_interrupt`) and resume (`_start`) buttons in exports list page.


https://github.com/user-attachments/assets/982f2074-52be-4681-a165-e67223865909



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
