### PR TITLE
Orders: Allow to cancel authorized payment orders

### DIFF
--- a/apps/orders/src/components/OrderSummary/orderDictionary.ts
+++ b/apps/orders/src/components/OrderSummary/orderDictionary.ts
@@ -49,6 +49,8 @@ export function getTriggerAttributes(order: Order): UITriggerAttributes[] {
 
     case 'approved:authorized:unfulfilled':
     case 'approved:authorized:not_required':
+      return ['_cancel', '_capture']
+
     case 'approved:authorized:in_progress':
     case 'approved:authorized:fulfilled':
       return ['_capture']


### PR DESCRIPTION
Closes commercelayer/issues-app#548

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR enables the functionality to cancel orders `approved` with payment status `authorized`.


<img width="728" height="163" alt="image" src="https://github.com/user-attachments/assets/16e3fe61-f038-46a0-a495-637b84bcbaee" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
