### PR TITLE
Orders: Update conditions to make customer address editable

### DIFF
--- a/apps/orders/src/components/OrderAddresses.tsx
+++ b/apps/orders/src/components/OrderAddresses.tsx
@@ -24,7 +24,8 @@ export const OrderAddresses = withSkeletonTemplate<Props>(
     const { isEditing } = useOrderStatus(order)
     const { mutateOrder } = useOrderDetails(order.id)
     const isEditable =
-      isEditing || (order.status !== 'draft' && order.status !== 'pending')
+      isEditing ||
+      (order.status !== 'draft' && order.fulfillment_status !== 'fulfilled')
     const { Overlay: AssignAddressOverlay, open: openAssignAddressOverlay } =
       useCustomerAddressOverlay(order, () => {
         void mutateOrder()

--- a/apps/orders/src/pages/Home.tsx
+++ b/apps/orders/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   useCoreSdkProvider,
   useResourceFilters,
+  useTokenProvider,
   useTranslation
 } from '@commercelayer/app-elements'
 import { Link, useLocation } from 'wouter'
@@ -22,6 +23,7 @@ function Home(): React.JSX.Element {
   const [, setLocation] = useLocation()
   const { t } = useTranslation()
   const { sdkClient } = useCoreSdkProvider()
+  const { canUser } = useTokenProvider()
   const search = useSearch()
   const { data: counters, isLoading: isLoadingCounters } = useListCounters()
 
@@ -33,44 +35,46 @@ function Home(): React.JSX.Element {
     <HomePageLayout
       title={t('resources.orders.name_other')}
       toolbar={{
-        buttons: [
-          {
-            icon: 'plus',
-            label: `${t('common.new')} ${t('resources.orders.name').toLowerCase()}`,
-            size: 'small',
-            onClick: () => {
-              void sdkClient.markets
-                .list({
-                  fields: ['id'],
-                  filters: {
-                    disabled_at_null: true
-                  },
-                  pageSize: 1
-                })
-                .then((markets) => {
-                  if (markets.meta.recordCount > 1) {
-                    setLocation(appRoutes.new.makePath({}))
-                  } else {
-                    const [resource] = markets
-                    if (resource != null) {
-                      void sdkClient.orders
-                        .create({
-                          market: {
-                            type: 'markets',
-                            id: resource.id
-                          }
-                        })
-                        .then((order) => {
-                          setLocation(
-                            appRoutes.new.makePath({ orderId: order.id })
-                          )
-                        })
-                    }
-                  }
-                })
-            }
-          }
-        ]
+        buttons: canUser('create', 'orders')
+          ? [
+              {
+                icon: 'plus',
+                label: `${t('common.new')} ${t('resources.orders.name').toLowerCase()}`,
+                size: 'small',
+                onClick: () => {
+                  void sdkClient.markets
+                    .list({
+                      fields: ['id'],
+                      filters: {
+                        disabled_at_null: true
+                      },
+                      pageSize: 1
+                    })
+                    .then((markets) => {
+                      if (markets.meta.recordCount > 1) {
+                        setLocation(appRoutes.new.makePath({}))
+                      } else {
+                        const [resource] = markets
+                        if (resource != null) {
+                          void sdkClient.orders
+                            .create({
+                              market: {
+                                type: 'markets',
+                                id: resource.id
+                              }
+                            })
+                            .then((order) => {
+                              setLocation(
+                                appRoutes.new.makePath({ orderId: order.id })
+                              )
+                            })
+                        }
+                      }
+                    })
+                }
+              }
+            ]
+          : undefined
       }}
     >
       <SearchWithNav


### PR DESCRIPTION
Closes commercelayer/issues-app#310

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Now customer addresses in order details page is always editable unless the order in in `draft` or fulfilment status is `fulfilled`

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
