### PR TITLE
Promotions: Add external_includes field to external promotion

### DIFF
--- a/apps/promotions/src/components/PromotionForm.tsx
+++ b/apps/promotions/src/components/PromotionForm.tsx
@@ -212,7 +212,7 @@ export function PromotionForm({
             {promotionId != null ? 'Update' : 'Create promotion'}
           </Button>
 
-          <Spacer top='2'>
+          <Spacer top='4' bottom='8'>
             <HookedValidationApiError apiError={apiError} />
           </Spacer>
         </Spacer>

--- a/apps/promotions/src/data/formConverters/promotion.ts
+++ b/apps/promotions/src/data/formConverters/promotion.ts
@@ -1,4 +1,5 @@
 import type { promotionConfig } from '#data/promotions/config'
+import { parseIncludes } from '#data/promotions/configs/external_promotions'
 import type { Promotion } from '#types'
 import { type z } from 'zod'
 
@@ -12,7 +13,11 @@ export function promotionToFormValues(promotion?: Promotion) {
     ...promotion,
     starts_at: new Date(promotion.starts_at),
     expires_at: new Date(promotion.expires_at),
-    show_priority: promotion.priority != null
+    show_priority: promotion.priority != null,
+    external_includes:
+      'external_includes' in promotion
+        ? promotion.external_includes?.map((item) => item.trim()).join(', ')
+        : undefined
   }
 
   if (promotion.type === 'flex_promotions') {
@@ -66,6 +71,15 @@ export function formValuesToPromotion(
                 ? formValues.sku_list
                 : null
           }
+        : undefined,
+    external_includes:
+      'external_includes' in formValues && formValues.external_includes != null
+        ? toIncludesArray(formValues.external_includes as string)
         : undefined
   }
+}
+
+function toIncludesArray(value?: string | null): string[] | null {
+  if (value == null || value.trim() === '') return null
+  return [...new Set(parseIncludes(value))]
 }

--- a/apps/promotions/src/data/formConverters/promotion.ts
+++ b/apps/promotions/src/data/formConverters/promotion.ts
@@ -80,6 +80,9 @@ export function formValuesToPromotion(
 }
 
 function toIncludesArray(value?: string | null): string[] | null {
-  if (value == null || value.trim() === '') return null
-  return [...new Set(parseIncludes(value))]
+  if (value == null || value.trim() === '') {
+    return null
+  }
+  const includes = parseIncludes(value)
+  return includes.length > 0 ? includes : null
 }

--- a/apps/promotions/src/data/promotions/configs/external_promotions.tsx
+++ b/apps/promotions/src/data/promotions/configs/external_promotions.tsx
@@ -20,6 +20,21 @@ export default {
     formType: genericPromotionOptions.merge(
       z.object({
         promotion_url: z.string().url(),
+        external_includes: z
+          .string()
+          .nullish()
+          .refine(
+            (value) => {
+              if (value == null || value.trim() === '') {
+                return true
+              }
+              return parseIncludes(value).every(isValidResourceName)
+            },
+            {
+              message:
+                'Please provide a comma-separated list of valid resource names.'
+            }
+          ),
         sku_list: z.string().nullish()
       })
     ),
@@ -37,6 +52,27 @@ export default {
                     external promotions guide
                   </a>{' '}
                   for setup.
+                </>
+              )
+            }}
+          />
+        </Spacer>
+        <Spacer top='6'>
+          <HookedInput
+            name='external_includes'
+            label='External includes'
+            hint={{
+              text: (
+                <>
+                  Comma-separated resource names for the request payload. Leave
+                  empty for defaults.{' '}
+                  <a
+                    href='https://docs.commercelayer.io/core/external-resources#custom-include-list'
+                    target='_blank'
+                    rel='noreferrer'
+                  >
+                    Learn more
+                  </a>
                 </>
               )
             }}
@@ -61,7 +97,37 @@ export default {
         <ListDetailsItem label='External service URL' gutter='none'>
           {promotion.promotion_url}
         </ListDetailsItem>
+        {promotion.external_includes != null && (
+          <ListDetailsItem label='External Includes' gutter='none'>
+            <div>
+              {promotion.external_includes
+                .map((item) => item.trim())
+                .join(', ')}
+            </div>
+          </ListDetailsItem>
+        )}
       </>
     )
   }
 } satisfies Pick<PromotionConfig, 'external_promotions'>
+
+export function parseIncludes(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean)
+    )
+  ]
+}
+
+/**
+ * Valid resource names may contain lowercase letters, underscores, and dots only.
+ * Examples:
+ * - valid: `orders`, `shipments_items`, `customer.addresses`
+ * - invalid: `Order`, `line-items`, `sku list`, `items/sku`
+ */
+export function isValidResourceName(item: string): boolean {
+  return /^[a-z_.]+$/.test(item)
+}

--- a/apps/promotions/src/data/promotions/configs/external_promotions.tsx
+++ b/apps/promotions/src/data/promotions/configs/external_promotions.tsx
@@ -98,7 +98,7 @@ export default {
           {promotion.promotion_url}
         </ListDetailsItem>
         {promotion.external_includes != null && (
-          <ListDetailsItem label='External Includes' gutter='none'>
+          <ListDetailsItem label='Includes' gutter='none'>
             <div>
               {promotion.external_includes
                 .map((item) => item.trim())


### PR DESCRIPTION
Related to commercelayer/issues-app#532

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've added `external_includes` field to external promotion form.

<img width="696" height="263" alt="image" src="https://github.com/user-attachments/assets/4244825f-e4c2-4433-9721-a87045b451be" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
