### PR TITLE
Better handle error states in various detail pages to not showing mocked data

### DIFF
--- a/apps/bundles/src/pages/BundleDetails.tsx
+++ b/apps/bundles/src/pages/BundleDetails.tsx
@@ -71,6 +71,35 @@ export const BundleDetails: FC = () => {
     ])
   }
 
+  if (error != null) {
+    return (
+      <PageLayout
+        mode={mode}
+        title="Bundles"
+        navigationButton={{
+          onClick: () => {
+            goBack({
+              currentResourceId: bundleId,
+              defaultRelativePath: appRoutes.list.makePath({}),
+            })
+          },
+          label: "Bundles",
+          icon: "arrowLeft",
+        }}
+        scrollToTop
+      >
+        <EmptyState
+          title="Not authorized"
+          action={
+            <Link href={goBackUrl}>
+              <Button variant="primary">Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
+  }
+
   return (
     <PageLayout
       mode={mode}
@@ -94,100 +123,89 @@ export const BundleDetails: FC = () => {
       scrollToTop
       gap="only-top"
     >
-      {error != null ? (
-        <EmptyState
-          title="Not authorized"
-          action={
-            <Link href={goBackUrl}>
-              <Button variant="primary">Go back</Button>
-            </Link>
-          }
-        />
-      ) : (
-        <>
-          <SkeletonTemplate isLoading={isLoading}>
-            <Spacer bottom="4">
-              <Spacer top="14">
-                <SkuDescription resource={bundle} />
-              </Spacer>
-              <Spacer top="14">
-                <BundleSkuList bundle={bundle} />
-              </Spacer>
-              <Spacer top="14">
-                <BundleInfo bundle={bundle} />
-              </Spacer>
-              <Spacer top="14">
-                <ResourceDetails
-                  resource={bundle}
-                  onUpdated={async () => {
-                    void mutateBundle()
-                  }}
-                />
-              </Spacer>
-              {!isMockedId(bundle.id) && (
-                <>
-                  <Spacer top="14">
-                    <ResourceTags
-                      resourceType="bundles"
-                      resourceId={bundle.id}
-                      overlay={{ title: pageTitle }}
-                      onTagClick={(tagId) => {
-                        setLocation(
-                          appRoutes.list.makePath({}, `tags_id_in=${tagId}`),
-                        )
-                      }}
-                    />
-                  </Spacer>
-                  <Spacer top="14">
-                    <ResourceMetadata
-                      resourceType="bundles"
-                      resourceId={bundle.id}
-                      overlay={{
-                        title: pageTitle,
-                      }}
-                    />
-                  </Spacer>
-                </>
-              )}
+      <>
+        <SkeletonTemplate isLoading={isLoading}>
+          <Spacer bottom="4">
+            <Spacer top="14">
+              <SkuDescription resource={bundle} />
             </Spacer>
-          </SkeletonTemplate>
-          {canUser("destroy", "bundles") && (
-            <DeleteOverlay backgroundColor="light">
-              <PageLayout
-                title={`Confirm that you want to delete the ${bundle.code} (${bundle.name}) bundle.`}
-                description="This action cannot be undone, proceed with caution."
-                minHeight={false}
-                navigationButton={{
-                  onClick: () => {
-                    close()
-                  },
-                  label: `Cancel`,
-                  icon: "x",
+            <Spacer top="14">
+              <BundleSkuList bundle={bundle} />
+            </Spacer>
+            <Spacer top="14">
+              <BundleInfo bundle={bundle} />
+            </Spacer>
+            <Spacer top="14">
+              <ResourceDetails
+                resource={bundle}
+                onUpdated={async () => {
+                  void mutateBundle()
                 }}
+              />
+            </Spacer>
+            {!isMockedId(bundle.id) && (
+              <>
+                <Spacer top="14">
+                  <ResourceTags
+                    resourceType="bundles"
+                    resourceId={bundle.id}
+                    overlay={{ title: pageTitle }}
+                    onTagClick={(tagId) => {
+                      setLocation(
+                        appRoutes.list.makePath({}, `tags_id_in=${tagId}`),
+                      )
+                    }}
+                  />
+                </Spacer>
+                <Spacer top="14">
+                  <ResourceMetadata
+                    resourceType="bundles"
+                    resourceId={bundle.id}
+                    overlay={{
+                      title: pageTitle,
+                    }}
+                  />
+                </Spacer>
+              </>
+            )}
+          </Spacer>
+        </SkeletonTemplate>
+        {canUser("destroy", "bundles") && (
+          <DeleteOverlay backgroundColor="light">
+            <PageLayout
+              title={`Confirm that you want to delete the ${bundle.code} (${bundle.name}) bundle.`}
+              description="This action cannot be undone, proceed with caution."
+              minHeight={false}
+              navigationButton={{
+                onClick: () => {
+                  close()
+                },
+                label: `Cancel`,
+                icon: "x",
+              }}
+            >
+              <Button
+                variant="danger"
+                size="small"
+                disabled={isDeleting}
+                onClick={(e) => {
+                  setIsDeleting(true)
+                  e.stopPropagation()
+                  void sdkClient.bundles
+                    .delete(bundle.id)
+                    .then(() => {
+                      setLocation(appRoutes.list.makePath({}))
+                    })
+                    .catch(() => {})
+                }}
+                fullWidth
               >
-                <Button
-                  variant="danger"
-                  size="small"
-                  disabled={isDeleting}
-                  onClick={(e) => {
-                    setIsDeleting(true)
-                    e.stopPropagation()
-                    void sdkClient.bundles
-                      .delete(bundle.id)
-                      .then(() => {
-                        setLocation(appRoutes.list.makePath({}))
-                      })
-                      .catch(() => {})
-                  }}
-                  fullWidth
-                >
-                  Delete bundle
-                </Button>
-              </PageLayout>
-            </DeleteOverlay>
-          )}
-        </>
-      )}
+                Delete bundle
+              </Button>
+            </PageLayout>
+          </DeleteOverlay>
+        )}
+      </>
     </PageLayout>
   )
 }

--- a/apps/customers/src/pages/CustomerDetails.tsx
+++ b/apps/customers/src/pages/CustomerDetails.tsx
@@ -97,6 +97,35 @@ export function CustomerDetails(): React.JSX.Element {
     ])
   }
 
+  if (error != null) {
+    return (
+      <PageLayout
+        mode={mode}
+        title="Customers"
+        navigationButton={{
+          label: t("common.back"),
+          icon: "arrowLeft",
+          onClick: () => {
+            goBack({
+              currentResourceId: customerId,
+              defaultRelativePath: appRoutes.list.makePath(),
+            })
+          },
+        }}
+        scrollToTop
+      >
+        <EmptyState
+          title={t("common.not_authorized")}
+          action={
+            <Link href={appRoutes.list.makePath()}>
+              <Button variant="primary">{t("common.go_back")}</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
+  }
+
   return (
     <PageLayout
       mode={mode}
@@ -129,88 +158,76 @@ export function CustomerDetails(): React.JSX.Element {
       gap="only-top"
       scrollToTop
     >
-      {error != null ? (
-        <EmptyState
-          title={t("common.not_authorized")}
-          action={
-            <Link href={appRoutes.list.makePath()}>
-              <Button variant="primary">{t("common.go_back")}</Button>
-            </Link>
-          }
-        />
-      ) : (
-        <SkeletonTemplate isLoading={isLoading}>
-          <Spacer bottom="4">
-            <CustomerAnonymization customerId={customer.id} />
-            <Spacer top="14">
-              <CustomerInfo customer={customer} />
-            </Spacer>
-            <Spacer top="14">
-              <CustomerLastOrders />
-            </Spacer>
-            <Spacer top="14">
-              <CustomerWallet
-                customer={customer}
-                onRemovedPaymentSource={() => {
-                  void mutateCustomer()
-                }}
-              />
-            </Spacer>
-            <Spacer top="14">
-              <CustomerAddresses
-                customer={customer}
-                onRemovedAddress={() => {
-                  void mutateCustomer()
-                }}
-              />
-            </Spacer>
-
-            <Spacer top="14">
-              <ResourceDetails
-                resource={customer}
-                onUpdated={async () => {
-                  void mutateCustomer()
-                }}
-              />
-            </Spacer>
-
-            {!isMockedId(customer.id) && (
-              <>
-                <Spacer top="14">
-                  <ResourceTags
-                    resourceType="customers"
-                    resourceId={customer.id}
-                    overlay={{ title: pageTitle }}
-                    onTagClick={(tagId) => {
-                      setLocation(
-                        appRoutes.list.makePath(`tags_id_in=${tagId}`),
-                      )
-                    }}
-                  />
-                </Spacer>
-                <Spacer top="14">
-                  <ResourceMetadata
-                    resourceType="customers"
-                    resourceId={customer.id}
-                    overlay={{
-                      title: pageTitle,
-                    }}
-                  />
-                </Spacer>
-              </>
-            )}
-            <Spacer top="14">
-              <ResourceAttachments
-                resourceType="customers"
-                resourceId={customer.id}
-              />
-            </Spacer>
-            <Spacer top="14">
-              <CustomerTimeline customer={customer} />
-            </Spacer>
+      <SkeletonTemplate isLoading={isLoading}>
+        <Spacer bottom="4">
+          <CustomerAnonymization customerId={customer.id} />
+          <Spacer top="14">
+            <CustomerInfo customer={customer} />
           </Spacer>
-        </SkeletonTemplate>
-      )}
+          <Spacer top="14">
+            <CustomerLastOrders />
+          </Spacer>
+          <Spacer top="14">
+            <CustomerWallet
+              customer={customer}
+              onRemovedPaymentSource={() => {
+                void mutateCustomer()
+              }}
+            />
+          </Spacer>
+          <Spacer top="14">
+            <CustomerAddresses
+              customer={customer}
+              onRemovedAddress={() => {
+                void mutateCustomer()
+              }}
+            />
+          </Spacer>
+
+          <Spacer top="14">
+            <ResourceDetails
+              resource={customer}
+              onUpdated={async () => {
+                void mutateCustomer()
+              }}
+            />
+          </Spacer>
+
+          {!isMockedId(customer.id) && (
+            <>
+              <Spacer top="14">
+                <ResourceTags
+                  resourceType="customers"
+                  resourceId={customer.id}
+                  overlay={{ title: pageTitle }}
+                  onTagClick={(tagId) => {
+                    setLocation(appRoutes.list.makePath(`tags_id_in=${tagId}`))
+                  }}
+                />
+              </Spacer>
+              <Spacer top="14">
+                <ResourceMetadata
+                  resourceType="customers"
+                  resourceId={customer.id}
+                  overlay={{
+                    title: pageTitle,
+                  }}
+                />
+              </Spacer>
+            </>
+          )}
+          <Spacer top="14">
+            <ResourceAttachments
+              resourceType="customers"
+              resourceId={customer.id}
+            />
+          </Spacer>
+          <Spacer top="14">
+            <CustomerTimeline customer={customer} />
+          </Spacer>
+        </Spacer>
+      </SkeletonTemplate>
+
       {canUser("destroy", "customers") && <DeleteOverlay />}
       <ResetPasswordOverlay />
     </PageLayout>

--- a/apps/returns/src/hooks/useReturnDetails.tsx
+++ b/apps/returns/src/hooks/useReturnDetails.tsx
@@ -18,6 +18,7 @@ export function useReturnDetails(id: string) {
     isLoading,
     mutate: mutateReturn,
     isValidating,
+    error,
   } = useCoreApi(
     "returns",
     "retrieve",
@@ -34,5 +35,5 @@ export function useReturnDetails(id: string) {
     },
   )
 
-  return { returnObj, isLoading, mutateReturn, isValidating }
+  return { returnObj, isLoading, mutateReturn, isValidating, error }
 }

--- a/apps/returns/src/pages/ReturnDetails.tsx
+++ b/apps/returns/src/pages/ReturnDetails.tsx
@@ -35,9 +35,10 @@ function ReturnDetails(): React.JSX.Element {
 
   const returnId = params?.returnId ?? ""
 
-  const { returnObj, isLoading, mutateReturn } = useReturnDetails(returnId)
+  const { returnObj, isLoading, mutateReturn, error } =
+    useReturnDetails(returnId)
 
-  if (returnId === undefined || !canUser("read", "returns")) {
+  if (returnId === undefined || !canUser("read", "returns") || error != null) {
     return (
       <PageLayout
         title={t("resources.returns.name_other")}

--- a/apps/sku_lists/src/pages/SkuListDetails.tsx
+++ b/apps/sku_lists/src/pages/SkuListDetails.tsx
@@ -70,7 +70,7 @@ export const SkuListDetails = (
   if (error != null) {
     return (
       <PageLayout
-        title={skuList?.name}
+        title="SKU List"
         navigationButton={{
           onClick: () => {
             setLocation(appRoutes.list.makePath({}))

--- a/apps/stock_transfers/src/hooks/useStockTransferDetails.tsx
+++ b/apps/stock_transfers/src/hooks/useStockTransferDetails.tsx
@@ -17,6 +17,7 @@ export function useStockTransferDetails(id: string) {
     isLoading,
     mutate: mutateStockTransfer,
     isValidating,
+    error,
   } = useCoreApi(
     "stock_transfers",
     "retrieve",
@@ -33,5 +34,5 @@ export function useStockTransferDetails(id: string) {
     },
   )
 
-  return { stockTransfer, isLoading, mutateStockTransfer, isValidating }
+  return { stockTransfer, isLoading, mutateStockTransfer, isValidating, error }
 }

--- a/apps/stock_transfers/src/pages/StockTransferDetails.tsx
+++ b/apps/stock_transfers/src/pages/StockTransferDetails.tsx
@@ -43,7 +43,7 @@ export function StockTransferDetails(): React.JSX.Element {
 
   const stockTransferId = params?.stockTransferId ?? ""
 
-  const { stockTransfer, isLoading, mutateStockTransfer } =
+  const { stockTransfer, isLoading, mutateStockTransfer, error } =
     useStockTransferDetails(stockTransferId)
 
   const triggerMenuActions = useMemo(() => {
@@ -53,7 +53,11 @@ export function StockTransferDetails(): React.JSX.Element {
   const { show: showCancelOverlay, Overlay: CancelOverlay } = useCancelOverlay()
   const { dispatch } = useTriggerAttribute(stockTransfer.id)
 
-  if (stockTransferId === "" || !canUser("read", "stock_transfers")) {
+  if (
+    stockTransferId === "" ||
+    !canUser("read", "stock_transfers") ||
+    error != null
+  ) {
     return (
       <PageLayout
         title="Stock transfers"

--- a/apps/webhooks/src/hooks/useWebhookDetails.tsx
+++ b/apps/webhooks/src/hooks/useWebhookDetails.tsx
@@ -9,6 +9,7 @@ export function useWebhookDetails(id: string) {
     isLoading,
     mutate: mutateWebhook,
     isValidating,
+    error,
   } = useCoreApi(
     "webhooks",
     "retrieve",
@@ -25,5 +26,5 @@ export function useWebhookDetails(id: string) {
     },
   )
 
-  return { webhook, isLoading, mutateWebhook, isValidating }
+  return { webhook, isLoading, mutateWebhook, isValidating, error }
 }

--- a/apps/webhooks/src/pages/WebhookDetails.tsx
+++ b/apps/webhooks/src/pages/WebhookDetails.tsx
@@ -24,9 +24,10 @@ export const WebhookDetails: FC = () => {
   const [, setLocation] = useLocation()
 
   const webhookId = params?.webhookId ?? ""
-  const { webhook, isLoading, mutateWebhook } = useWebhookDetails(webhookId)
+  const { webhook, isLoading, mutateWebhook, error } =
+    useWebhookDetails(webhookId)
 
-  if (webhookId == null || !canUser("read", "webhooks")) {
+  if (webhookId == null || !canUser("read", "webhooks") || error != null) {
     return (
       <PageLayout
         title="Webhook details"


### PR DESCRIPTION
Closes commercelayer/issues-app#485


## What I did

I've updated the following apps to force an early return in case of error while fetching data. Same as we already do in all other apps.
This prevents to show an error message mixed with mocked data. 

- Bundles
- Customers
- Returns
- SKU lists
- Stock transfers
- Webhooks


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
