### PR TITLE
Orders: Show configured return reasons when creating a return

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@vitejs/plugin-react": "^5.2.0",
     "lodash-es": "^4.18.1",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/my_sample_app/package.json
+++ b/apps/my_sample_app/package.json
@@ -25,7 +25,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/orders/src/components/FormFieldItems.tsx
+++ b/apps/orders/src/components/FormFieldItems.tsx
@@ -3,8 +3,11 @@ import {
   HookedInputCheckboxGroup,
   type HookedInputCheckboxGroupProps,
   Input,
+  InputSelect,
+  isSingleValueSelected,
   ListItem,
   Text,
+  useCoreApi,
   useTranslation,
 } from "@commercelayer/app-elements"
 import type { LineItem } from "@commercelayer/sdk"
@@ -19,6 +22,14 @@ interface Props {
 
 export function FormFieldItems({ lineItems }: Props): React.JSX.Element {
   const { t } = useTranslation()
+  const { data: organization, isLoading } = useCoreApi(
+    "organization",
+    "retrieve",
+    [],
+  )
+
+  const returnReasons: string[] =
+    organization?.config?.apps?.returns?.return_reasons ?? []
 
   if (lineItems.length === 0) {
     return <div>{t("common.no_items")}</div>
@@ -28,14 +39,22 @@ export function FormFieldItems({ lineItems }: Props): React.JSX.Element {
     <HookedInputCheckboxGroup
       name="items"
       title="Items"
-      options={lineItems.map(makeOptionItem)}
+      options={lineItems.map((item) =>
+        makeOptionItem({ item, isLoading, returnReasons }),
+      )}
     />
   )
 }
 
-function makeOptionItem(
-  item: LineItem,
-): HookedInputCheckboxGroupProps["options"][number] {
+function makeOptionItem({
+  item,
+  isLoading,
+  returnReasons,
+}: {
+  item: LineItem
+  isLoading: boolean
+  returnReasons: string[]
+}): HookedInputCheckboxGroupProps["options"][number] {
   return {
     value: item.id,
     content: (
@@ -63,7 +82,13 @@ function makeOptionItem(
         </ListItem>
       </>
     ),
-    checkedElement: <OptionInputReason item={item} />,
+    checkedElement: (
+      <OptionInputReason
+        item={item}
+        returnReasons={returnReasons}
+        isLoading={isLoading}
+      />
+    ),
     quantity: {
       min: 1,
       max: item.quantity,
@@ -72,7 +97,11 @@ function makeOptionItem(
 }
 
 /** When checked, show input for reason */
-const OptionInputReason: FC<{ item: LineItem }> = ({ item }) => {
+const OptionInputReason: FC<{
+  item: LineItem
+  returnReasons: string[]
+  isLoading: boolean
+}> = ({ item, returnReasons, isLoading }) => {
   const { watch, setValue } = useFormContext<ReturnFormValues>()
   const items = watch("items") ?? []
   const isSelected = items.find(({ value }) => value === item.id) != null
@@ -84,7 +113,30 @@ const OptionInputReason: FC<{ item: LineItem }> = ({ item }) => {
     }
   }, [isSelected, reason])
 
-  return (
+  return returnReasons.length > 0 || isLoading ? (
+    <InputSelect
+      isLoading={isLoading}
+      initialValues={returnReasons.map((reason) => ({
+        value: reason,
+        label: reason,
+      }))}
+      isCreatable
+      isClearable
+      placeholder="Select or add a reason (optional)"
+      menuPortalTarget={document.body}
+      onSelect={(selected) => {
+        const value =
+          isSingleValueSelected(selected) && typeof selected.value === "string"
+            ? selected.value
+            : ""
+        setReason(value)
+        setValue(
+          `items.${items.findIndex(({ value }) => value === item.id)}.reason`,
+          value,
+        )
+      }}
+    />
+  ) : (
     <Input
       value={reason}
       placeholder="Add a reason (optional)"

--- a/apps/orders/src/components/FormFieldItems.tsx
+++ b/apps/orders/src/components/FormFieldItems.tsx
@@ -130,10 +130,10 @@ const OptionInputReason: FC<{
             ? selected.value
             : ""
         setReason(value)
-        setValue(
-          `items.${items.findIndex(({ value }) => value === item.id)}.reason`,
-          value,
-        )
+        const itemIndex = items.findIndex(({ value }) => value === item.id)
+        if (itemIndex !== -1) {
+          setValue(`items.${itemIndex}.reason`, value)
+        }
       }}
     />
   ) : (
@@ -142,10 +142,10 @@ const OptionInputReason: FC<{
       placeholder="Add a reason (optional)"
       onChange={(e) => {
         setReason(e.target.value)
-        setValue(
-          `items.${items.findIndex(({ value }) => value === item.id)}.reason`,
-          e.target.value,
-        )
+        const itemIndex = items.findIndex(({ value }) => value === item.id)
+        if (itemIndex !== -1) {
+          setValue(`items.${itemIndex}.reason`, e.target.value)
+        }
       }}
     />
   )

--- a/apps/orders/src/hooks/useOrderToolbar.tsx
+++ b/apps/orders/src/hooks/useOrderToolbar.tsx
@@ -42,6 +42,7 @@ export function useOrderToolbar({ order }: { order: Order }): OrderToolbar {
     return showReturnDropDownItem
       ? {
           label: t("apps.orders.tasks.request_return"),
+          icon: "arrowUUpLeft",
           onClick: () => {
             setLocation(appRoutes.return.makePath({ orderId: order.id }))
           },

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.5.0",
+    "@commercelayer/app-elements": "7.6.0",
     "lodash-es": "^4.18.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -109,8 +109,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -185,8 +185,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -267,8 +267,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -343,8 +343,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -428,8 +428,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -507,8 +507,8 @@ importers:
   apps/my_sample_app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -586,8 +586,8 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -668,8 +668,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -747,8 +747,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -829,8 +829,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -908,8 +908,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -987,8 +987,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1069,8 +1069,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1154,8 +1154,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1230,8 +1230,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1309,8 +1309,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1385,8 +1385,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1485,8 +1485,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1537,8 +1537,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.5.0
-        version: 7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.6.0
+        version: 7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1765,8 +1765,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@commercelayer/app-elements@7.5.0':
-    resolution: {integrity: sha512-RM5777rFHE0+VF92vBDOw9GL2D0BMIvU0BAB+on8UY5LluT27H+H8RehtOGvJFwo6kaXvN2tXhi/aY3r+1gXYw==}
+  '@commercelayer/app-elements@7.6.0':
+    resolution: {integrity: sha512-1DZDphvgfuTFUTo3WQ4rmuDrPQVyVTVif6tDgEutzC0gPJhiATLgkf/kls47ggnm/A99XRNE1xqQk0DU+kyGdg==}
     engines: {node: '>=22', pnpm: '10'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -5454,7 +5454,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
-  '@commercelayer/app-elements@7.5.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))':
+  '@commercelayer/app-elements@7.6.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))':
     dependencies:
       '@commercelayer/js-auth': 7.4.1
       '@commercelayer/sdk': 6.57.0


### PR DESCRIPTION
Related to commercelayer/issues-app#613

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

It's now possibile to select a preconfigured return reasons when creating a new return

<img width="693" height="285" alt="image" src="https://github.com/user-attachments/assets/9e2f29e4-498d-4047-ba69-45a37f163f58" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
