### PR TITLE
Orders: Keep selected return reasons on checked items

### DIFF
--- a/apps/bundles/package.json
+++ b/apps/bundles/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/customers/package.json
+++ b/apps/customers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/exports/package.json
+++ b/apps/exports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/gift_cards/package.json
+++ b/apps/gift_cards/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-virtual": "^3.13.25",

--- a/apps/imports/package.json
+++ b/apps/imports/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@vitejs/plugin-react": "^5.2.0",
     "lodash-es": "^4.18.1",

--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/my_sample_app/package.json
+++ b/apps/my_sample_app/package.json
@@ -25,7 +25,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/orders/package.json
+++ b/apps/orders/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/price_lists/package.json
+++ b/apps/price_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/promotions/package.json
+++ b/apps/promotions/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/returns/package.json
+++ b/apps/returns/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/shipments/package.json
+++ b/apps/shipments/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/sku_lists/package.json
+++ b/apps/sku_lists/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/skus/package.json
+++ b/apps/skus/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "dashboard-apps-common": "workspace:*",

--- a/apps/stock_transfers/package.json
+++ b/apps/stock_transfers/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/subscriptions/package.json
+++ b/apps/subscriptions/package.json
@@ -26,7 +26,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/tags/package.json
+++ b/apps/tags/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/apps/webhooks/package.json
+++ b/apps/webhooks/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "lodash-es": "^4.18.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "@commercelayer/sdk": "6.57.0",
     "@hookform/resolvers": "^3.10.0",
     "date-fns": "^4.1.0",

--- a/packages/index/package.json
+++ b/packages/index/package.json
@@ -13,7 +13,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "7.7.0",
+    "@commercelayer/app-elements": "7.7.1",
     "lodash-es": "^4.18.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   apps/bundles:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -109,8 +109,8 @@ importers:
   apps/customers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -185,8 +185,8 @@ importers:
   apps/exports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -267,8 +267,8 @@ importers:
   apps/gift_cards:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -346,8 +346,8 @@ importers:
   apps/imports:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -431,8 +431,8 @@ importers:
   apps/inventory:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -510,8 +510,8 @@ importers:
   apps/my_sample_app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -589,8 +589,8 @@ importers:
   apps/orders:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -671,8 +671,8 @@ importers:
   apps/price_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -750,8 +750,8 @@ importers:
   apps/promotions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -832,8 +832,8 @@ importers:
   apps/returns:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -911,8 +911,8 @@ importers:
   apps/shipments:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -990,8 +990,8 @@ importers:
   apps/sku_lists:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1072,8 +1072,8 @@ importers:
   apps/skus:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1157,8 +1157,8 @@ importers:
   apps/stock_transfers:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1233,8 +1233,8 @@ importers:
   apps/subscriptions:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1312,8 +1312,8 @@ importers:
   apps/tags:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1388,8 +1388,8 @@ importers:
   apps/webhooks:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1488,8 +1488,8 @@ importers:
   packages/common:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       '@commercelayer/sdk':
         specifier: 6.57.0
         version: 6.57.0
@@ -1540,8 +1540,8 @@ importers:
   packages/index:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 7.7.0
-        version: 7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
+        specifier: 7.7.1
+        version: 7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1768,8 +1768,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@commercelayer/app-elements@7.7.0':
-    resolution: {integrity: sha512-U3QvllKyQdM6asoa/ueIU/kh3Qpno2KqIeA8Wf4oo1q1NbgKOwih6JvtWwqWb6E0c9G/v/soaMoHGzXag7xX0A==}
+  '@commercelayer/app-elements@7.7.1':
+    resolution: {integrity: sha512-6YIceEJQs9Uoqb3MdkKlpJT83aQvt4Isw5zg0PvXc58turUJj8sKnWNp4Ryu9QrA4pbOBmF+XPwscQI1qkfpGw==}
     engines: {node: '>=22', pnpm: '10'}
     peerDependencies:
       '@commercelayer/sdk': ^6.x
@@ -5466,7 +5466,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.13':
     optional: true
 
-  '@commercelayer/app-elements@7.7.0(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))':
+  '@commercelayer/app-elements@7.7.1(@commercelayer/sdk@6.57.0)(query-string@9.3.1)(react-dom@19.2.4(react@19.2.4))(react-gtm-module@2.0.11)(react-hook-form@7.62.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(wouter@3.9.0(react@19.2.4))':
     dependencies:
       '@commercelayer/js-auth': 7.4.1
       '@commercelayer/sdk': 6.57.0


### PR DESCRIPTION
Closes commercelayer/issues-app#625

### Description
Bumps the `app-elements` dependency across all apps to fix return reasons (fix is inside HookedInputCheckboxGroup component)