### PR TITLE
Add `upcoming` Stock Transfers home link

### DIFF
--- a/apps/stock_transfers/src/pages/Home.tsx
+++ b/apps/stock_transfers/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import {
   Icon,
   List,
   ListItem,
+  RadialProgress,
   SkeletonTemplate,
   Spacer,
   StatusIcon,
@@ -147,6 +148,20 @@ export function Home(): React.JSX.Element {
                 }
               >
                 <Text weight="semibold">{presets.history.viewTitle}</Text>
+                <Icon name="caretRight" />
+              </ListItem>
+            </Link>
+            <Link
+              href={appRoutes.list.makePath(
+                {},
+                adapters.adaptFormValuesToUrlQuery({
+                  formValues: presets.upcoming,
+                }),
+              )}
+              asChild
+            >
+              <ListItem icon={<RadialProgress size="small" />}>
+                <Text weight="semibold">{presets.upcoming.viewTitle}</Text>
                 <Icon name="caretRight" />
               </ListItem>
             </Link>


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/649

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added `Upcoming` link in the home links of the Stock Transfers app to easily access upcoming stock transfers.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
